### PR TITLE
show error message on login failed

### DIFF
--- a/src/components/LoginButton.vue
+++ b/src/components/LoginButton.vue
@@ -9,6 +9,12 @@ export default {
   methods: {
     signIn () {
       return this.$store.dispatch('auth/login')
+        .catch(e => {
+          this.$swal.fire({
+            icon: 'error',
+            title: e.message || 'Terjadi Kesalahan'
+          })
+        })
     }
   }
 }

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -53,6 +53,9 @@ export const actions = {
             'Content-Type': 'application/json'
           }
         }).then(r => r.data)
+        .catch(e => {
+          throw e.response.data.errors
+        })
       if (res && res.auth_token) {
         setToken(res.auth_token)
         setTokenInCookie(res.auth_token, {
@@ -66,6 +69,7 @@ export const actions = {
       }
     } catch (e) {
       commit(types.UNAUTHENTICATED)
+      throw e
     } finally {
       commit(types.AUTH_INITIALIZED)
     }


### PR DESCRIPTION
Bug:
- some users can't login into app, in which said user is being redirected back to /login page as if nothing happens in the process.

Cause:
- said user's email are not registered in the database, resulted in error 400 response.
- app has no handler for such error

Fix:
- setup error handler for auth endpoint