### PR TITLE
LogbookCRUD: consume get, insert, and update logbook using new logbook data structure

### DIFF
--- a/src/components/Form/DocumentFileInput.vue
+++ b/src/components/Form/DocumentFileInput.vue
@@ -1,0 +1,109 @@
+<template>
+  <div>
+    <FormInputHeader
+      :label-for="name"
+      :title="title"
+      :subtitle="subtitle"
+      :required="required"
+    >
+      <template #title>
+        <slot name="title"></slot>
+      </template>
+      <template #subtitle>
+        <slot name="subtitle"></slot>
+      </template>
+    </FormInputHeader>
+    <FileSelector
+      :file="mFile"
+      :url="mUrl"
+      v-bind="$props"
+      @preview="onSaveDocument"
+      @change="onSelectedFileChange"
+    />
+  </div>
+</template>
+
+<script>
+import { saveAs } from 'file-saver'
+import { props, components } from './input-mixin'
+
+export default {
+  components: {
+    ...components,
+    FileSelector: () => import('./FileSelector')
+  },
+  model: {
+    prop: 'value',
+    event: 'input'
+  },
+  props: {
+    ...props,
+    path: {
+      type: String,
+      default: null
+    },
+    url: {
+      type: String,
+      default: null
+    }
+  },
+  data () {
+    return {
+      mFile: null,
+      mUrl: null
+    }
+  },
+  computed: {
+    isFileFromStorage () {
+      return typeof this.fullPath === 'string' && this.fullPath.startsWith('http')
+    },
+    isSelectedFileChanged () {
+      return this.mUrl && this.mUrl !== this.url
+    }
+  },
+  watch: {
+    url: {
+      immediate: true,
+      handler (v) {
+        this.mUrl = v
+      }
+    }
+  },
+  methods: {
+    getDocumentTaskFile (path) {
+      return this.$store.dispatch('logbook-documents/getDocument', { path })
+    },
+    onSelectedFileChange (url, file) {
+      this.mUrl = url
+      this.mFile = file
+    },
+    async onSaveDocument () {
+      try {
+        if (this.mFile instanceof File) {
+          saveAs(this.mFile, `${this.mFile.name}`)
+        } else if (typeof this.url === 'string' && this.url.startsWith('http')) {
+          this.$swal.fire({
+            title: 'Mengambil data...',
+            onBeforeOpen: () => this.$swal.showLoading()
+          })
+          const file = await this.$promiseMinDelay(this.getDocumentTaskFile(this.path), 1000)
+          this.$swal.close()
+          saveAs(file, file.name)
+        }
+      } catch (e) {
+        this.$swal.fire({
+          icon: 'error',
+          text: 'Terjadi kesalahan dalam pembacaan dokumen',
+          confirmButtonText: 'Tutup'
+        })
+      }
+    },
+    getSelectedFile () {
+      return this.isSelectedFileChanged ? this.mFile : null
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/src/components/Form/EvidenceImageInput.vue
+++ b/src/components/Form/EvidenceImageInput.vue
@@ -1,0 +1,94 @@
+<template>
+  <div>
+    <FormInputHeader
+      :label-for="name"
+      :title="title"
+      :subtitle="subtitle"
+      :required="required"
+    >
+      <template #title>
+        <slot name="title"></slot>
+      </template>
+      <template #subtitle>
+        <slot name="subtitle"></slot>
+      </template>
+    </FormInputHeader>
+    <template v-if="mUrl">
+      <EvidenceImagePreview
+        :url="mUrl"
+        :disabled="disabled"
+        @delete="onDelete"
+      />
+    </template>
+    <template v-else>
+      <FileSelector
+        :url="mUrl"
+        v-bind="$props"
+        @change="onSelectedFileChange"
+      />
+    </template>
+  </div>
+</template>
+
+<script>
+import { props, components } from './input-mixin'
+
+export default {
+  components: {
+    ...components,
+    EvidenceImagePreview: () => import('./EvidenceImagePreview'),
+    FileSelector: () => import('./FileSelector')
+  },
+  model: {
+    prop: 'value',
+    event: 'input'
+  },
+  props: {
+    ...props,
+    path: {
+      type: String,
+      default: null
+    },
+    url: {
+      type: String,
+      default: null
+    }
+  },
+  data () {
+    return {
+      mFile: null,
+      mUrl: null,
+      mBlob: null
+    }
+  },
+  computed: {
+    isSelectedFileChanged () {
+      return this.mUrl && this.mUrl !== this.url
+    }
+  },
+  watch: {
+    url: {
+      immediate: true,
+      handler (v) {
+        this.mUrl = v
+      }
+    }
+  },
+  methods: {
+    onDelete () {
+      this.mUrl = null
+      this.mFile = null
+    },
+    onSelectedFileChange (url, file) {
+      this.mUrl = url
+      this.mFile = file
+    },
+    getSelectedFile () {
+      return this.isSelectedFileChanged ? this.mFile : null
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/src/components/Form/EvidenceImagePreview.vue
+++ b/src/components/Form/EvidenceImagePreview.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="form-input__file-preview">
+    <figcaption class="mr-4">
+      <img
+        :src="url"
+        class="form-input__file-preview__image"
+        @click.prevent="onDownload"
+      >
+    </figcaption>
+    <div class="mt-4 md:mt-0 self-stretch md:flex-auto flex flex-col justify-between">
+      <p
+        v-if="!disabled"
+        class="mt-2 inline-block self-end text-sm"
+      >
+        <button
+          class="w-auto py-2 px-4 mr-4 rounded border border-solid border-blue-500 text-blue-500 hover:opacity-50 hover:bg-blue-100"
+          @click="onDownload"
+        >
+          Unduh
+        </button>
+        <button
+          class="w-24 py-2 px-4 rounded border border-solid border-red-600 text-red-500 hover:opacity-50 hover:bg-red-100"
+          @click="$emit('delete')"
+        >
+          Hapus
+        </button>
+      </p>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    disabled: {
+      type: Boolean,
+      default: false
+    },
+    url: {
+      type: String,
+      required: true
+    }
+  },
+  methods: {
+    onDownload (e) {
+      window.open(this.url, '_blank')
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/src/components/Form/FileSelector.vue
+++ b/src/components/Form/FileSelector.vue
@@ -1,0 +1,147 @@
+<template>
+  <ValidationProvider
+    :rules="rules"
+    :custom-messages="customMessages"
+    #default="{failed, errors}"
+    tag="div"
+    ref="validator"
+  >
+    <div :class="{'form-input__file mb-2': true, 'is-invalid': failed}">
+      <a
+        href="javascript:void(0)"
+        target="_blank"
+        @click.prevent="onPreview"
+      >
+        <span>
+          {{ filename || $attrs.placeholder }}
+        </span>
+      </a>
+      <button
+        v-if="!disabled"
+        :disabled="disabled"
+        @click="onChooseFile"
+      >
+        Pilih
+      </button>
+    </div>
+    <input
+      v-show="false"
+      ref="input"
+      :name="name"
+      :rules="rules"
+      type="file"
+      :multiple="false"
+      v-bind="$attrs"
+      @change="onChange($event)"
+    >
+    <p
+      v-if="errors.length"
+      class="form-input__error-hint"
+    >
+      <slot name="error">
+        {{errors[0]}}
+      </slot>
+    </p>
+  </ValidationProvider>
+</template>
+
+<script>
+import { props } from './input-mixin'
+
+export default {
+  inheritAttrs: false,
+  props: {
+    ...props,
+    url: {
+      type: String,
+      default: null
+    },
+    file: {
+      type: File,
+      default: null
+    }
+  },
+  data () {
+    return {
+      mFile: null,
+      mUrl: null
+    }
+  },
+  computed: {
+    filename () {
+      if (this.mFile instanceof File) {
+        return this.mFile.name
+      }
+      if (typeof this.url === 'string' && this.url.startsWith('http')) {
+        const i = this.url.lastIndexOf('document/')
+        return this.url.substring(i)
+      }
+      return null
+    }
+  },
+  watch: {
+    url: {
+      immediate: true,
+      handler (v) {
+        this.mUrl = v
+      }
+    },
+    file: {
+      immediate: true,
+      handler (v) {
+        this.mFile = v
+      }
+    }
+  },
+  methods: {
+    onPreview () {
+      this.$emit('preview')
+    },
+    resetInputElement () {
+      if (this.$refs.input) {
+        this.$refs.input.type = ''
+        this.$refs.input.setAttribute('type', '')
+        return this.$nextTick()
+          .then(() => {
+            this.$refs.input.type = 'file'
+            this.$refs.input.setAttribute('type', 'file')
+          })
+      }
+      return Promise.resolve()
+    },
+    onChooseFile () {
+      this.mFile = null
+      this.mUrl = null
+      this.resetInputElement()
+        .then(() => {
+          this.$refs.input.click()
+        })
+    },
+    onRemoveFile () {
+      this.resetInputElement()
+        .then(() => {
+          this.mFile = null
+          this.mUrl = null
+          this.emitChange(null, null, null)
+          return this.$nextTick()
+        }).then(() => {
+          this.$refs.validator.validate()
+        })
+    },
+    onChange (e) {
+      if (e.target.files) {
+        this.mFile = e.target.files.length ? e.target.files[0] : null
+
+        this.mUrl = window.URL.createObjectURL(this.mFile)
+        this.emitChange(this.mUrl, this.mFile)
+      }
+    },
+    emitChange (url, file) {
+      this.$emit('change', url, file)
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/src/components/FormLogbook/index.vue
+++ b/src/components/FormLogbook/index.vue
@@ -14,21 +14,26 @@
         :custom-messages="{
           required: 'Nama proyek harus diisi'
         }"
-        @change="onSelectedProjectChanged">
-        <template v-if="!isViewingOnly" #subtitle>
+        @change="onSelectedProjectChanged"
+      >
+        <template
+          v-if="!isViewingOnly"
+          #subtitle
+        >
           <p>
             <i class="text-gray-600">
               Nama proyek/produk tidak ada? Kontak admin via
             </i>
             <a
               class="cursor-pointer hover:underline"
-              :href="adminWhatsappBacklink">
+              :href="adminWhatsappBacklink"
+            >
               <b class="text-green-500">Whatsapp</b>
             </a>
           </p>
         </template>
       </FormSelect>
-      <br/>
+      <br />
       <FormInput
         name="nameTask"
         title="Nama Tugas"
@@ -38,8 +43,9 @@
         :custom-messages="{
           required: 'Nama tugas harus diisi'
         }"
-        v-model="payload.nameTask"/>
-      <br/>
+        v-model="payload.nameTask"
+      />
+      <br />
       <FormInputDateTime
         name="dateTask"
         title="Tanggal"
@@ -52,18 +58,20 @@
         }"
         v-model="payload.dateTask"
       />
-      <br/>
+      <br />
       <FormInput
         name="workPlace"
         title="Tempat"
         type="text"
+        placeholder="Tempat bekerja"
         :disabled="!isEditable"
         rules="required"
         :custom-messages="{
-          required: 'Tempat harus diisi'
+          required: 'Tempat bekerja harus diisi'
         }"
-        v-model="payload.workPlace"/>
-      <br/>
+        v-model="payload.workPlace"
+      />
+      <br />
       <div class="relative">
         <FormRadioButtonGroup
           name="difficultyTask"
@@ -88,7 +96,7 @@
           </template>
         </FormRadioButtonGroup>
       </div>
-      <br/>
+      <br />
       <FormRadioButtonGroup
         class="mb-2"
         name="isMainTask"
@@ -103,23 +111,21 @@
         }"
         v-model="payload.isMainTask"
       />
-      <br/>
-      <FormInputFile
-          name="evidenceTask"
-          title="Screenshot / Foto Hasil Kerja"
-          :value.sync="evidenceTaskFileURL"
-          :file.sync="evidenceTaskFileBlob"
-          :filename.sync="evidenceTaskFilename"
-          :disabled="!isEditable"
-          :renameable="false"
-          :download-on-click="true"
-          rules="required|mimes:image/*"
-          accept="image/*"
-          :custom-messages="{
-            required: 'Evidence harus diisi'
-          }"
-          />
-      <br/>
+      <br />
+      <FormInputEvidence
+        ref="formInputEvidence"
+        name="evidenceTask"
+        title="Screenshot / Foto Hasil Kerja"
+        :url.sync="payload.evidenceTaskURL"
+        :path="payload.evidenceTaskPath"
+        :disabled="!isEditable"
+        rules="required|mimes:image/*"
+        accept="image/*"
+        :custom-messages="{
+          required: 'Evidence harus diisi'
+        }"
+      />
+      <br />
       <FormRadioButtonGroup
         class="mb-2"
         name="selectedDocumentType"
@@ -132,30 +138,32 @@
         @change="onDocumentTypeSelectionChanged"
       >
         <template #subtitle>
-          <span v-if="!isViewingOnly" class="font-bold text-gray-500">
+          <span
+            v-if="!isViewingOnly"
+            class="font-bold text-gray-500"
+          >
             *Pilih salah satu
           </span>
         </template>
       </FormRadioButtonGroup>
-      <FormInputFile
+      <FormInputDocument
         v-if="isUsingFileAsDocument"
+        ref="formInputDocumentFile"
         name="documentTask"
         title="File Dokumen"
-        placeholder="Choose file..."
+        placeholder="Pilih file"
         :disabled="!isEditable"
-        :value.sync="documentTaskFileURL"
-        :file.sync="documentTaskFileBlob"
-        :filename.sync="documentTaskFilename"
+        :url.sync="payload.documentTaskURL"
+        :path="payload.documentTaskPath"
         :required="false"
-        :renameable="false"
-        :download-on-click="true"
       >
         <template #title>
           <span></span>
         </template>
-      </FormInputFile>
+      </FormInputDocument>
       <FormInput
         v-if="isUsingLinkAsDocument"
+        ref="formInputDocumentLink"
         type="text"
         name="documentTask"
         title="Link Dokumen"
@@ -166,12 +174,13 @@
           regex: 'Link harus dalam bentuk URL yang valid'
         }"
         :required="false"
-        v-model="documentTaskLink">
+        v-model="documentTaskLink"
+      >
         <template #title>
           <span></span>
         </template>
       </FormInput>
-      <br/>
+      <br />
       <FormInput
         type="text"
         name="organizerTask"
@@ -181,19 +190,25 @@
         :custom-messages="{
           required: 'Penyelenggara harus diisi'
         }"
-        v-model="payload.organizerTask"/>
-      <br/>
-      <div v-if="isEditable" class="flex justify-end">
+        v-model="payload.organizerTask"
+      />
+      <br />
+      <div
+        v-if="isEditable"
+        class="flex justify-end"
+      >
         <button
           class="mr-4 button focus:outline-none
                  bg-gray-200 hover:bg-gray-300 text-gray-500"
-          @click="onCancel">
+          @click="onCancel"
+        >
           Cancel
         </button>
         <button
           class="button focus:outline-none
                  bg-brand-blue hover:bg-brand-blue-lighter text-white"
-          @click="handleSubmit(beforeSave)">
+          @click="handleSubmit(beforeSave)"
+        >
           Save
         </button>
       </div>
@@ -204,10 +219,10 @@
 <script>
 import FormSelect from '../Form/Select'
 import FormInput from '../Form/Input'
-import FormInputFile from '../Form/InputFile'
+import FormInputEvidence from '../Form/EvidenceImageInput'
+import FormInputDocument from '../Form/DocumentFileInput'
 import FormInputDateTime from '../Form/InputDateTime'
 import FormRadioButtonGroup from '../Form/RadioButtonGroup'
-import { GroupwareAPI } from '../../lib/axios'
 import _cloneDeep from 'lodash/cloneDeep'
 
 const DOCUMENT_TYPE = {
@@ -216,13 +231,11 @@ const DOCUMENT_TYPE = {
 }
 
 const modelData = {
-  'dateTask': null, // timestamptz '2020-06-11T06:55:24.698Z'
+  'dateTask': new Date().toISOString(), // timestamptz '2020-06-11T06:55:24.698Z'
   'projectId': null, // ?
   'projectName': null, // ?
   'nameTask': null, // ?
   'difficultyTask': null, // number in range of [1, 5],
-  'evidenceTask': null, // URI 'http://'
-  'documentTask': null, // URI 'http://'
   'organizerTask': null, // ?,
   'isMainTask': null,
   'isDocumentLink': true,
@@ -245,7 +258,8 @@ export default {
   components: {
     FormSelect,
     FormInput,
-    FormInputFile,
+    FormInputEvidence,
+    FormInputDocument,
     FormInputDateTime,
     FormRadioButtonGroup
   },
@@ -291,14 +305,7 @@ export default {
         }
       ],
       selectedDocumentType: DOCUMENT_TYPE.LINK,
-      documentTaskFileURL: null,
-      documentTaskFileBlob: null,
-      documentTaskFilename: null,
       documentTaskLink: null,
-
-      evidenceTaskFileURL: null,
-      evidenceTaskFileBlob: null,
-      evidenceTaskFilename: null,
 
       maxDateTime: new Date().toISOString()
     }
@@ -335,26 +342,11 @@ export default {
           this.$emit('logbook:not-found', id)
           return
         }
-        const { evidenceTask, documentTask, isDocumentLink } = logbook
+        const { documentTaskURL, isDocumentLink } = logbook
         this.originalData = _cloneDeep(logbook)
         this.payload = logbook
         this.selectedDocumentType = logbook.isDocumentLink === true ? DOCUMENT_TYPE.LINK : DOCUMENT_TYPE.FILE
-        await this.getEvidenceTaskFile(evidenceTask.filePath)
-          .then(({ name, url, file }) => {
-            this.evidenceTaskFilename = name
-            this.evidenceTaskFileURL = url
-            this.evidenceTaskFileBlob = file
-          })
-        if (isDocumentLink === false) {
-          await this.getDocumentTaskFile(documentTask.filePath)
-            .then(({ name, url, file }) => {
-              this.documentTaskFilename = name
-              this.documentTaskFileURL = url
-              this.documentTaskFileBlob = file
-            })
-        } else if (isDocumentLink === true) {
-          this.documentTaskLink = documentTask.fileURL
-        }
+        this.documentTaskLink = isDocumentLink ? documentTaskURL : null
       }
     }
   },
@@ -373,45 +365,8 @@ export default {
     },
     getLogbookFromDatabase (id) {
       return Promise.resolve(null)
-    },
-    async getEvidenceTaskFile (filePath) {
-      if (typeof filePath !== 'string' || !filePath.length) {
-        return Promise.resolve({})
-      }
-      const __filePath = filePath.replace('image/', 'image-blob/')
-      const mimetype = filePath.substring(filePath.lastIndexOf('.') + 1)
-      const blob = await GroupwareAPI.get(`file/${__filePath}`)
-        .then(r => {
-          return fetch(r.data).then(r => r.blob())
-        })
-      const file = new File([blob], `${new Date().getTime()}`, {
-        type: `image/${mimetype}`
-      })
-      const url = window.URL.createObjectURL(file)
-      return {
-        name: filePath,
-        url,
-        file
-      }
-    },
-    async getDocumentTaskFile (filePath) {
-      if (typeof filePath !== 'string' || !filePath.length) {
-        return Promise.resolve({})
-      }
-      const __filePath = filePath.replace('image/', 'image-blob/')
-      const blob = await GroupwareAPI.get(`file/${__filePath}`, {
-        responseType: 'blob'
-      })
-        .then(r => {
-          return r.data
-        })
-      const file = new File([blob], `${new Date().getTime()}`)
-      const url = window.URL.createObjectURL(file)
-      return {
-        name: filePath,
-        url,
-        file
-      }
+      // TODO: bentukan API by id harusnya sama dengan keluaran list
+      // return this.$store.dispatch('logbook-list/getLogbookById', { id })
     },
     resetPayload () {
       this.payload = Object.assign({}, modelData)
@@ -434,8 +389,10 @@ export default {
     },
     createFormDataToPost () {
       const {
-        evidenceTask,
-        documentTask,
+        evidenceTaskURL,
+        evidenceTaskPath,
+        documentTaskURL,
+        documentTaskPath,
         ...rest
       } = this.payload
 
@@ -443,23 +400,31 @@ export default {
       Object.entries(rest).forEach(([key, value]) => {
         formData.append(key, value)
       })
-      formData.append('evidenceTask', this.evidenceTaskFileBlob)
-      if (this.isUsingFileAsDocument) {
-        formData.append('documentTask', this.documentTaskFileBlob)
-      } else if (this.isUsingLinkAsDocument) {
-        formData.append('documentTask', this.documentTaskLink)
-      }
 
-      return formData
+      try {
+        const evidenceFile = this.$refs.formInputEvidence.getSelectedFile()
+        formData.append('evidenceTask', evidenceFile)
+        if (this.isUsingLinkAsDocument) {
+          formData.append('documentTask', this.documentTaskLink)
+        } else if (this.isUsingFileAsDocument) {
+          const documentFile = this.$refs.formInputDocumentFile.getSelectedFile()
+          formData.append('documentTask', documentFile)
+        }
+        return formData
+      } catch (e) {
+        return null
+      }
     },
-    post () {
+    async post () {
       const formData = this.createFormDataToPost()
       return this.$store.dispatch('logbook-list/insertLogbook', formData)
     },
     createFormDataToPut () {
       const {
-        evidenceTask,
-        documentTask,
+        evidenceTaskPath,
+        evidenceTaskURL,
+        documentTaskPath,
+        documentTaskURL,
         isDocumentLink,
         ...rest
       } = this.payload
@@ -468,25 +433,22 @@ export default {
       Object.entries(rest).forEach(([key, value]) => {
         formData.append(key, value)
       })
-      if (this.payload.evidenceTask.filePath === this.evidenceTaskFilename) {
-        formData.append('evidenceTask', null)
-      } else {
-        formData.append('evidenceTask', this.evidenceTaskFileBlob)
-      }
-      if (this.isUsingFileAsDocument) {
-        formData.append('isDocumentLink', false)
-        if (this.payload.documentTask.filePath !== this.documentTaskFilename) {
-          formData.append('documentTask', this.documentTaskFileBlob)
-        } else {
-          formData.append('documentTask', null)
+
+      try {
+        const evidenceFile = this.$refs.formInputEvidence.getSelectedFile()
+        formData.append('evidenceTask', evidenceFile)
+        if (this.isUsingLinkAsDocument) {
+          formData.append('documentTask', this.documentTaskLink)
+        } else if (this.isUsingFileAsDocument) {
+          const documentFile = this.$refs.formInputDocumentFile.getSelectedFile()
+          formData.append('documentTask', documentFile)
         }
-      } else {
-        formData.append('isDocumentLink', true)
-        formData.append('documentTask', this.documentTaskLink)
+        return formData
+      } catch (e) {
+        return null
       }
-      return formData
     },
-    put () {
+    async put () {
       const formData = this.createFormDataToPut()
       return this.$store.dispatch('logbook-list/updateLogbook', {
         id: this.id,
@@ -552,5 +514,4 @@ export default {
 </script>
 
 <style>
-
 </style>

--- a/src/store/modules/logbook-documents.js
+++ b/src/store/modules/logbook-documents.js
@@ -1,0 +1,34 @@
+import Vue from 'vue'
+import { GroupwareAPI } from '../../lib/axios'
+
+export const state = () => ({
+  documents: {}
+})
+
+export const mutations = {
+  keepDocumentInCache (state, { id, file }) {
+    if (typeof id === 'string' && id.length && file instanceof File) {
+      Vue.set(state.documents, id, file)
+    }
+  }
+}
+
+export const actions = {
+  async getDocument ({ state, commit }, { path, cacheFirst = true } = {}) {
+    if (typeof path !== 'string' || !path.length) {
+      return Promise.reject(new Error('path is either empty or not a string'))
+    }
+    if (path in state.documents === false || cacheFirst === false) {
+      const blob = await GroupwareAPI.get(`file/${path}`, {
+        responseType: 'blob'
+      }).then(r => r.data)
+      const filename = path.replace('document/', '')
+      const file = new File([blob], filename)
+      commit('keepDocumentInCache', {
+        id: path,
+        file: file
+      })
+    }
+    return state.documents[path]
+  }
+}

--- a/src/store/modules/logbook-list.js
+++ b/src/store/modules/logbook-list.js
@@ -75,6 +75,13 @@ export const actions = {
         commit(SET_RESULT, e)
       })
   },
+  async getLogbookById (_, { id }) {
+    if (typeof id !== 'string' || !id.length) {
+      return Promise.reject(new Error('id is either empty or not a string'))
+    }
+    return GroupwareAPI.get(`logbook/${id}`)
+      .then(r => r.data)
+  },
   insertLogbook (_, payload) {
     return GroupwareAPI.post('/logbook/', payload)
   },

--- a/src/styles/elements/_form.scss
+++ b/src/styles/elements/_form.scss
@@ -54,9 +54,10 @@
 
 .form-input {
   &__file {
-    @apply w-full flex flex-row justify-start items-stretch;
+    @apply w-full flex flex-row justify-start items-stretch rounded-md overflow-hidden;
     > button {
       @apply order-2 w-24
+      flex-none
       inline-block py-2 px-4 
       rounded-tr
       rounded-br
@@ -71,12 +72,16 @@
     }
 
     > a {
-      text-overflow: ellipsis;
+      min-height: 2.5rem;
       @apply flex-auto order-1
       flex flex-row justify-start items-center 
       px-4
       overflow-hidden
       bg-gray-200;
+
+      > span {
+        @apply block truncate;
+      }
 
       &[href] {
         @apply text-brand-blue font-bold cursor-pointer;


### PR DESCRIPTION
added:
- components
    - DocumentFileInput
    - EvidenceImageInput
    - EvidenceImagePreview
    - FileSelector (generic)
- vuex module
   - logbook-documents
    Each logbook's document must be fetched as blob from API. This module act as a cache to prevent subsequent request for the same file in a single session.
    - logbook-list
    Add action for getting logbook by id. Action is not used yet, since it has a different response data structure with `logbook/list` endpoint.

modified:
- `component/FormLogbook/index.vue`
    - replace FormInputFile for uploading document and evidence with aforementioned components above
- `style/element/_forms.scss`
    - change form input file classes styling