### PR TITLE
RefreshToken: remove auth header on refresh token req

### DIFF
--- a/src/lib/axios.js
+++ b/src/lib/axios.js
@@ -51,6 +51,7 @@ export function useRefreshTokenHook ({
     },
     async function onError (error) {
       if (error && error.response.status === 401) {
+        setToken(null)
         try {
           await getNewToken()
           if (typeof onRefreshSuccess === 'function') {


### PR DESCRIPTION
Remove request headers "Authorization" before calling refresh token API.