### PR TITLE
[hotfix] RefreshToken: fix refresh token flow

### DIFF
--- a/src/lib/axios.js
+++ b/src/lib/axios.js
@@ -18,7 +18,7 @@ export function setToken (token) {
   }
 }
 
-async function getNewToken () {
+export async function getNewToken () {
   const refreshToken = getRefreshTokenFromCookie()
   if (!refreshToken) {
     return Promise.reject(new Error('no refresh token'))
@@ -37,7 +37,10 @@ async function getNewToken () {
         setTokenInCookie(null)
         setToken(null)
       }
-      return true
+      return {
+        refreshToken: newRefreshToken,
+        authToken: newAuthToken
+      }
     })
 }
 

--- a/src/middleware/check-auth.js
+++ b/src/middleware/check-auth.js
@@ -1,6 +1,6 @@
 import store from '@/store'
 import { getTokenFromCookie } from '../lib/js-cookie'
-import { setToken } from '../lib/axios'
+import { setToken, getNewToken } from '../lib/axios'
 
 const publicPaths = ['/', '/login']
 const isPublicPath = (path) => {
@@ -13,7 +13,11 @@ const isPublicPath = (path) => {
 export default async (to, from, next) => {
   try {
     if (!store.state.auth.user && !store.state.auth.isInitialized) {
-      const t = getTokenFromCookie()
+      let t = getTokenFromCookie()
+      if (!t) {
+        const { authToken } = await getNewToken().catch(() => {})
+        t = authToken
+      }
       if (t) {
         setToken(t)
         await store


### PR DESCRIPTION
Ensure refresh token is fetched when token in cookie is empty.