### PR TITLE
DayoffForm: ensure end date is not earlier than start date

### DIFF
--- a/src/components/Attendance/DayoffForm/form.vue
+++ b/src/components/Attendance/DayoffForm/form.vue
@@ -41,7 +41,7 @@
           <InputDateTime
             name="endDate"
             type="date"
-            :min-datetime="minimumStartDate"
+            :min-datetime="startDateISOString"
             rules="required"
             :custom-messages="{
               required: 'Tanggal harus diisi'

--- a/src/components/Attendance/DayoffForm/form.vue
+++ b/src/components/Attendance/DayoffForm/form.vue
@@ -29,9 +29,10 @@
             name="startDate"
             type="date"
             :min-datetime="minimumStartDate"
-            rules="required"
+            rules="required|date_compare:lte,@endDate"
             :custom-messages="{
-              required: 'Tanggal harus diisi'
+              required: 'Tanggal harus diisi',
+              date_compare: 'Tanggal mulai harus lebih dulu dari tanggal akhir'
             }"
             placeholder="Tanggal Mulai"
             :value="startDateISOString"


### PR DESCRIPTION
Fixes:
- Selected dayoff end date can't be earlier than selected start date