### PR TITLE
fix infinite loop on refresh token error

### DIFF
--- a/src/lib/axios.js
+++ b/src/lib/axios.js
@@ -42,7 +42,7 @@ export async function getNewToken () {
         authToken: newAuthToken
       }
     }).catch((e) => {
-      return null
+      throw e
     })
 }
 
@@ -66,7 +66,6 @@ export function useRefreshTokenHook ({
           if (typeof onRefreshFailed === 'function') {
             await onRefreshFailed()
           }
-          throw error
         }
       } else {
         return Promise.reject(error)


### PR DESCRIPTION
Fix:
- remove infinite loop caused by uncatch error in refresh token API calls. Any error in refresh token API calls should only be handled by `onRefreshFailed` hook, without any further error thrown to the stack.