### PR TITLE
hotfix: ensure profile picture url is provided before accessing string 'match' method

### DIFF
--- a/src/lib/string.js
+++ b/src/lib/string.js
@@ -9,9 +9,13 @@ export function replaceNewLine (string) {
 export const googleDriveUrl = 'https://drive.google.com/thumbnail?&id='
 
 export function getIdFromUrl (url) {
-  let idImage = url.match(/[-\w]{25,}/)
-  if (idImage.length > 0) {
-    idImage = idImage[0]
+  // ensure that url is string, so `match` is a valid property
+  if (typeof url === 'string' && url.length) {
+    let idImage = url.match(/[-\w]{25,}/)
+    if (idImage.length > 0) {
+      idImage = idImage[0]
+    }
+    return idImage
   }
-  return idImage
+  return null
 }

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -107,7 +107,11 @@ export const actions = {
       await GroupwareAPI.get('/user/info')
         .then(r => r.data.data)
         .then(profile => {
-          const urlPhoto = googleDriveUrl + getIdFromUrl(profile.photo) + '&sz=w{{200}}-h{{100}}'
+          let urlPhoto
+          const uri = getIdFromUrl(profile.photo)
+          if (uri) {
+            urlPhoto = `${googleDriveUrl}${uri}&sz=w{{200}}-h{{100}}`
+          }
           commit(types.SET_USER, {
             user: {
               ...profile,


### PR DESCRIPTION
Bug:
- login using user whose profile picture is null
- this dialog would be shown
![image](https://user-images.githubusercontent.com/20709202/101778960-2ffff900-3b27-11eb-925e-879acda3bc6a.png)

Fixes:
- ensure that profile picture url has a valid string value, so that `match` function call is valid