### PR TITLE
replace 'adm' menu with backlink to JDS' Wiki

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -90,9 +90,9 @@ const menuItems = Object.freeze([
     icon: 'fa fa-book'
   },
   {
-    name: 'Administrasi',
-    href: ['https://forms.gle/Mw8uMqKKXS4bWMqW9', '_blank'],
-    icon: 'fa fa-id-card-alt'
+    name: 'Wiki',
+    href: ['https://wiki.digitalservice.id/', '_blank'],
+    icon: 'far fa-file-word'
   }
 ])
 


### PR DESCRIPTION
#### Related Task
- https://trello.com/c/DupK0Xmp : Ganti menu adminstrasi dengan nama menu Wiki JDS

#### Changes
Modified:
- Replace "Administrasi" menu with backlink to JDS' Wiki 