### PR TITLE
Ensure file selector validation is skipped if value is valid;

### DIFF
--- a/src/components/Form/FileSelector.vue
+++ b/src/components/Form/FileSelector.vue
@@ -2,6 +2,7 @@
   <ValidationProvider
     :rules="rules"
     :custom-messages="customMessages"
+    :disabled="isValidationDisabled"
     #default="{failed, errors}"
     tag="div"
     ref="validator"
@@ -71,6 +72,14 @@ export default {
     }
   },
   computed: {
+    isValidationDisabled () {
+      const { mUrl } = this
+      if (typeof mUrl !== 'string' || !mUrl.length) {
+        return false
+      }
+      // if mUrl starts with these string, assume file either has already been uploaded or changed
+      return ['http', 'blob:'].some((str) => mUrl.startsWith(str))
+    },
     filename () {
       if (this.mFile instanceof File) {
         return this.mFile.name


### PR DESCRIPTION
## Bug
### Steps to Repro
- Go to 'Laporan' menu in [staging app](https://deploy-preview-84--groupware-jds.netlify.app/)
- Choose any item in 'Laporan' table
- Click 'Edit' button
- At this point, edit form should've been shown
- Click save without performing any kind of edit

### Expected Result
- Save confirmation prompt is shown
or
- Window will scroll onto invalid field

### Actual Result
No confirmation prompt is shown. No invalid field is shown either.

### Cause
Evidence image `FileSelector` component is accepting `File` as `value`. Since data comes freshly from backend service, `value` is returned as `URILocator` string, so `ValidationObserver` sees this as invalid value.
This is not a problem on previous version since `FileSelector` is not rendered unless user is changing its image file. Now, `FileSelector` is always rendered regardless of any changes exist or not.

### Fixes
Conditionally set `disabled` prop on `FileSelector`'s `ValidationProvider`, so validation is performed accordingly.