### PR TITLE
OKR Code Reliability: change relevant <i> tags with <em>

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -16,7 +16,7 @@
 
     <template v-if="loading">
       <div class="w-screen h-screen flex justify-center items-center flex-wrap bg-brand-green">
-        <i class="block p-8 rounded-full bg-white shadow">
+        <i aria-hidden="true" class="block p-8 rounded-full bg-white shadow">
           <img class="block h-32 -ml-1 -mt-1" src="/img/icons/android-chrome-512x512.png" alt>
         </i>
       </div>

--- a/src/components/Announcement/AnnouncementDetail.vue
+++ b/src/components/Announcement/AnnouncementDetail.vue
@@ -3,7 +3,7 @@
     <template v-if="!isLoading">
       <div class="flex">
         <div class="flex items-center mx-auto mr-4">
-          <i class="fas fa-check-circle text-brand-green text-lg" />
+          <i aria-hidden="true" class="fas fa-check-circle text-brand-green text-lg" />
         </div>
         <div class="text-left flex-grow">
           <p class="text-sm leading-normal">{{ item.title }}</p>

--- a/src/components/Announcement/AnnouncementList.vue
+++ b/src/components/Announcement/AnnouncementList.vue
@@ -8,7 +8,7 @@
         <router-link :to="`/announcement/${item.id}`">
           <div class="flex">
             <div class="flex items-center mx-auto mr-4">
-              <i class="fas fa-star text-yellow-500 text-lg" />
+              <i aria-hidden="true" class="fas fa-star text-yellow-500 text-lg" />
             </div>
             <div class="text-left flex-grow">
               <p class="text-sm leading-normal">{{ item.title }}</p>

--- a/src/components/Attendance/DayoffList/card-list-item-skeleton.vue
+++ b/src/components/Attendance/DayoffList/card-list-item-skeleton.vue
@@ -3,10 +3,10 @@
     <div class="flex-1">
       <div class="w-full flex justify-between items-center">
         <p class="block w-1/2 h-3 mb-2 rounded-full bg-shimmering" />
-        <i class="flex-1" />
-        <i class="ml-2 flex-none inline-block w-8 h-8 rounded bg-shimmering" />
-        <i class="ml-2 flex-none inline-block w-8 h-8 rounded bg-shimmering" />
-        <i class="ml-2 flex-none inline-block w-8 h-8 rounded bg-shimmering" />
+        <em class="flex-1" />
+        <em class="ml-2 flex-none inline-block w-8 h-8 rounded bg-shimmering" />
+        <em class="ml-2 flex-none inline-block w-8 h-8 rounded bg-shimmering" />
+        <em class="ml-2 flex-none inline-block w-8 h-8 rounded bg-shimmering" />
       </div>
       <p class="block w-1/3 h-3 mb-2 rounded-full bg-shimmering" />
       <br />

--- a/src/components/CheckinsList.vue
+++ b/src/components/CheckinsList.vue
@@ -29,7 +29,7 @@
         <template v-else>
           <div class="w-full shadow bg-white mb-2 p-4">
             <div class="text-center">
-              <i class="far fa-4x fa-sad-tear mb-4 text-gray-600" />
+              <i aria-hidden="true" class="far fa-4x fa-sad-tear mb-4 text-gray-600" />
               <p class="text-sm">Belum ada yang checkin. Kantor sepi.</p>
             </div>
           </div>

--- a/src/components/Dashboard/AttendanceCardUser.vue
+++ b/src/components/Dashboard/AttendanceCardUser.vue
@@ -10,7 +10,7 @@
       <dl class="mx-0 pt-1 grid grid-cols-2 gap-2 sm:grid-cols-2 lg:grid-cols-2">
         <div class="bg-green-500 overflow-hidden grid grid-cols-2 shadow antialiased rounded-lg">
           <div class="text-center text-white text-7xl ml-4 mr-2 my-8 lg:my-4">
-            <i class="fa fa-user-check fa-2x lg:fa-3x" />
+            <i aria-hidden="true" class="fa fa-user-check fa-2x lg:fa-3x" />
           </div>
           <div class="text-center mr-2 sm:pl-8 lg:pr-8">
             <b class="text-sm text-justify text-white">Sudah Presensi</b>
@@ -24,7 +24,7 @@
         </div>
         <div class="bg-red-600 overflow-hidden grid grid-cols-2 shadow antialiased rounded-lg">
           <div class="text-center text-white text-7xl ml-4 mr-2 my-8 lg:my-4">
-            <i class="fa fa-user-times fa-2x lg:fa-3x" />
+            <i aria-hidden="true" class="fa fa-user-times fa-2x lg:fa-3x" />
           </div>
           <div class="text-center mr-2 sm:pl-8 lg:pr-8">
             <b class="text-sm text-justify text-white">Belum Presensi</b>
@@ -40,7 +40,7 @@
       <dl class="mx-0 pt-1 grid grid-cols-2 gap-2 sm:grid-cols-2 lg:grid-cols-2">
         <div class="bg-orange-500 overflow-hidden grid grid-cols-2 shadow antialiased rounded-lg">
           <div class="text-center text-white text-7xl ml-4 mr-2 my-8 lg:my-4">
-            <i class="fa fa-running fa-5x lg:fa-3x" />
+            <i aria-hidden="true" class="fa fa-running fa-5x lg:fa-3x" />
           </div>
           <div class="relative">
             <div class="absolute bottom-0 right-0 text-center text-xl mb-2 sm:my-12 lg:my-10 lg:mr-16" style="right: 5%;">
@@ -57,7 +57,7 @@
         <dl class="mx-0 pt-1 grid grid-row-2 gap-2 sm:grid-row-2 lg:grid-row-2">
             <div class="bg-blue-800 overflow-hidden grid grid-cols-2 shadow antialiased rounded-lg">
             <div class="text-center text-white text-7xl ml-4 mr-2 my-8 lg:my-4">
-                <i class="fa fa-building fa-2x lg:fa-3x" />
+                <i aria-hidden="true" class="fa fa-building fa-2x lg:fa-3x" />
             </div>
             <div class="text-center mr-2 sm:pl-8 lg:pr-8">
                 <b class="text-sm text-justify text-white">Ada di Kantor</b>
@@ -71,7 +71,7 @@
             </div>
             <div class="bg-blue-500 overflow-hidden grid grid-cols-2 shadow antialiased rounded-lg">
             <div class="text-center text-white text-7xl ml-4 mr-2 my-8 lg:my-4">
-                <i class="fa fa-book fa-2x lg:fa-3x" />
+                <i aria-hidden="true" class="fa fa-book fa-2x lg:fa-3x" />
             </div>
             <div class="text-center mr-2 sm:pl-8 lg:pr-8">
                 <b class="text-sm text-justify text-white">Izin tidak Masuk</b>
@@ -88,7 +88,7 @@
       <dl class="mx-0 pt-1 grid grid-cols-2 gap-2 sm:grid-cols-2 lg:grid-cols-2">
         <div class="bg-red-500 overflow-hidden grid grid-cols-2 shadow antialiased rounded-lg">
           <div class="text-center text-white text-7xl ml-4 mr-2 my-8 lg:my-4">
-            <i class="fa fa-calendar-day fa-2x lg:fa-3x" />
+            <i aria-hidden="true" class="fa fa-calendar-day fa-2x lg:fa-3x" />
           </div>
           <div class="text-center mr-2 sm:pl-8 lg:pr-8">
             <b class="text-sm text-justify text-white">Presensi akhir Pekan</b>
@@ -102,7 +102,7 @@
         </div>
         <div class="bg-blue-600 overflow-hidden grid grid-cols-2 shadow antialiased rounded-lg">
           <div class="text-center text-white text-7xl ml-4 mr-2 my-8 lg:my-4">
-            <i class="fa fa-car-side fa-2x lg:fa-3x" />
+            <i aria-hidden="true" class="fa fa-car-side fa-2x lg:fa-3x" />
           </div>
           <div class="text-center mr-2 sm:pl-8 lg:pr-8">
             <b class="text-sm text-justify text-white">Perjadin</b>

--- a/src/components/EventsList.vue
+++ b/src/components/EventsList.vue
@@ -7,7 +7,7 @@
             <div class="text-left flex-grow">
               <p class="text-sm leading-normal">{{ item['title'] }}</p>
               <p class="text-sm text-gray-600">{{ getDateTime(item) }}</p>
-              <p class="text-sm text-gray-600 mt-1"><i class="fas fa-map-marker-alt text-red-500 mr-1" /> Bandung</p>
+              <p class="text-sm text-gray-600 mt-1"><i aria-hidden="true" class="fas fa-map-marker-alt text-red-500 mr-1" /> Bandung</p>
             </div>
           </div>
         </div>

--- a/src/components/FeedbackList.vue
+++ b/src/components/FeedbackList.vue
@@ -10,7 +10,7 @@
             <div class="flex items-center block mx-auto mr-4">
               <span class="text-sm mr-2">{{ item['votes_count'] }}</span>
               <span @click="vote(item.id)">
-                <i class="fas fa-heart text-red-500" />
+                <i aria-hidden="true" class="fas fa-heart text-red-500" />
               </span>
             </div>
           </div>

--- a/src/components/Form/FilePreview.vue
+++ b/src/components/Form/FilePreview.vue
@@ -22,7 +22,7 @@
                             #default="{errors}">
           <label class="inline-block align-middle text-gray-700">
             Nama File
-            <i class="relative fa fa-pen float-right ml-2 text-gray-400" style="transform: translateY(2px);"></i>
+            <i aria-hidden="true" class="relative fa fa-pen float-right ml-2 text-gray-400" style="transform: translateY(2px);"></i>
           </label>
           <div class="mb-2 relative flex flex-row justify-start items-stretch border-b border-solid border-brand-blue">
               <input  class="block flex-auto text-gray-700 font-bold"

--- a/src/components/FormLogbook/InputLink.vue
+++ b/src/components/FormLogbook/InputLink.vue
@@ -16,14 +16,14 @@
   >
     <template #subtitle>
       <p class="text-gray-700">
-        Jika file hasil kerja berbentuk <i>offline</i> ataupun <i>private</i>, silakan terlebih dahulu
-        di <i>screenshot</i> hasil kerja lalu diupload ke
+        Jika file hasil kerja berbentuk <em>offline</em> ataupun <em>private</em>, silakan terlebih dahulu
+        di <em>screenshot</em> hasil kerja lalu diupload ke
         <a class="underline text-brand-blue"
           :href="jdsGoogleDriveLink"
           target="_blank">
-          <i>cloud storage JDS</i>
+          <em>cloud storage JDS</em>
         </a>
-        , dan simpan <i>link</i>-nya dibawah ini:
+        , dan simpan <em>link</em>-nya dibawah ini:
       </p>
     </template>
   </FormInput>

--- a/src/components/FormLogbook/InputProjectAutocomplete.vue
+++ b/src/components/FormLogbook/InputProjectAutocomplete.vue
@@ -36,7 +36,7 @@
         <ul>
           <template v-if="isSearching">
             <li key="isSearching" class="form-input-project__result-item text-center">
-              <i class="fa fa-2x fa-circle-notch text-gray-300" />
+              <i aria-hidden="true" class="fa fa-2x fa-circle-notch text-gray-300" />
             </li>
           </template>
           <template v-else-if="results && results.length">

--- a/src/components/FormLogbook/index.vue
+++ b/src/components/FormLogbook/index.vue
@@ -18,7 +18,7 @@
           #subtitle
         >
           <p>
-            <i class="text-gray-600">
+            <i aria-hidden="true" class="text-gray-600">
               Nama project Anda tidak ada? Kontak admin via
             </i>
             <a

--- a/src/components/HomeArticleList.vue
+++ b/src/components/HomeArticleList.vue
@@ -6,7 +6,7 @@
           <router-link :to="`/articles/${item.id}`">
             <div class="flex">
               <div class="flex items-center block mx-auto mr-4">
-                <i class="fas fa-check-circle text-brand-green text-lg" />
+                <i aria-hidden="true" class="fas fa-check-circle text-brand-green text-lg" />
               </div>
               <div class="text-left flex-grow">
                 <p class="text-sm leading-normal">{{ item['title'] }}</p>

--- a/src/components/LogbookList/card-list-item-skeleton.vue
+++ b/src/components/LogbookList/card-list-item-skeleton.vue
@@ -3,17 +3,17 @@
     <div class="flex-1">
       <div class="w-full mb-4 flex justify-between items-center">
         <p class="block w-1/4 h-3 mb-2 rounded-full bg-shimmering" />
-        <i class="flex-1" />
-        <i class="ml-2 flex-none inline-block w-8 h-8 rounded bg-shimmering" />
-        <i class="ml-2 flex-none inline-block w-8 h-8 rounded bg-shimmering" />
-        <i class="ml-2 flex-none inline-block w-8 h-8 rounded bg-shimmering" />
+        <em class="flex-1" />
+        <em class="ml-2 flex-none inline-block w-8 h-8 rounded bg-shimmering" />
+        <em class="ml-2 flex-none inline-block w-8 h-8 rounded bg-shimmering" />
+        <em class="ml-2 flex-none inline-block w-8 h-8 rounded bg-shimmering" />
       </div>
       <p class="block w-1/2 h-3 my-4 rounded-full bg-shimmering" />
       <div
         v-for="i in 3" :key="i"
         class="flex pt-4">
-        <i class="block w-1/3 h-3 mr-4 rounded-full bg-shimmering"></i>
-        <i class="block w-2/3 h-3 rounded-full bg-shimmering"></i>
+        <em class="block w-1/3 h-3 mr-4 rounded-full bg-shimmering"></em>
+        <em class="block w-2/3 h-3 rounded-full bg-shimmering"></em>
       </div>
     </div>
   </div>

--- a/src/components/LogbookList/card-list-item.vue
+++ b/src/components/LogbookList/card-list-item.vue
@@ -2,9 +2,9 @@
   <component :is="tag" class="logbook-cards__card">
     <div class="logbook-cards__card__header">
       <div>
-        <i class="logbook-cards__card__index">
+        <span class="logbook-cards__card__index">
           {{ index }}
-        </i>
+        </span>
       </div>
       <div class="whitespace-no-wrap">
         <button
@@ -13,7 +13,7 @@
           :title="action.title"
           :class="action.btnClassName"
           @click="action.clickHandler">
-          <i :class="action.iconClassName"></i>
+          <i aria-hidden="true" :class="action.iconClassName"></i>
         </button>
       </div>
     </div>

--- a/src/components/LogbookList/table-row.vue
+++ b/src/components/LogbookList/table-row.vue
@@ -20,14 +20,14 @@
         v-if="hasTupoksi"
         title="Tupoksi sudah diisi"
         class="data-status-chip is-success">
-        <i class="fa fa-check-circle"></i>
+        <i aria-hidden="true" class="fa fa-check-circle"></i>
       </span>
       <span
         v-else
         title="Tupoksi belum diisi"
         class="data-status-chip is-danger"
         @click="onEditLogbook">
-        <i class="fa fa-question-circle"></i>
+        <i aria-hidden="true" class="fa fa-question-circle"></i>
       </span>
     </td>
     <td>
@@ -37,7 +37,7 @@
           target="_blank"
           class="data-status-chip is-info"
           @click.prevent="onClickEvidence">
-          <i class="fa fa-file"></i>
+          <i aria-hidden="true" class="fa fa-file"></i>
         </a>
       </template>
       <i
@@ -53,21 +53,21 @@
         title="Lampiran sudah diisi"
         class="data-status-chip is-info"
         @click.prevent="onClickDocument">
-        <i class="fa fa-file"></i>
+        <i aria-hidden="true" class="fa fa-file"></i>
       </a>
       <span
         v-else
         title="Lampiran belum diisi"
         class="data-status-chip is-danger"
         @click="onEditLogbook">
-        <i class="fa fa-question-circle"></i>
+        <i aria-hidden="true" class="fa fa-question-circle"></i>
       </span>
     </td>
     <td class="whitespace-no-wrap">
       <button
         class="action-button is-success"
         @click="onEditLogbook">
-        <i class="fa fa-pencil-alt"></i>
+        <i aria-hidden="true" class="fa fa-pencil-alt"></i>
         <span class="text-xs">
           Edit
         </span>
@@ -75,7 +75,7 @@
       <button
         class="action-button is-danger"
         @click="beforeDeleteLogbook">
-        <i class="fa fa-trash"></i>
+        <i aria-hidden="true" class="fa fa-trash"></i>
         <span class="text-xs">
           Hapus
         </span>

--- a/src/components/MessagesList.vue
+++ b/src/components/MessagesList.vue
@@ -6,7 +6,7 @@
           <router-link :to="`/messages/${item.id}`">
             <div class="flex">
               <div class="flex items-center block mx-auto mr-4">
-                <i class="fas fa-envelope text-brand-green text-lg" />
+                <i aria-hidden="true" class="fas fa-envelope text-brand-green text-lg" />
               </div>
               <div class="text-left flex-grow">
                 <p class="text-sm leading-normal">{{ item['title'] }}</p>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -4,19 +4,19 @@
       <div class="flex items-center w-full lg:max-w-sm lg:mx-auto justify-around flex-wrap">
         <div class="text-center px-2 py-1">
           <router-link class="no-underline text-gray-700 block" to="/">
-            <i class="fas fa-home text-lg" />
+            <i aria-hidden="true" class="fas fa-home text-lg" />
             <p class="text-xs">Home</p>
           </router-link>
         </div>
         <div v-if="user" class="text-center px-2 py-1">
           <router-link class="no-underline text-gray-700 block" to="/profile">
-            <i class="far fa-user text-lg" />
+            <i aria-hidden="true" class="far fa-user text-lg" />
             <p class="text-xs">Profile</p>
           </router-link>
         </div>
         <div v-if="user" class="text-center px-2 py-1">
           <router-link class="no-underline text-gray-700 block" to="/messages">
-            <i class="far fa-bell text-lg" />
+            <i aria-hidden="true" class="far fa-bell text-lg" />
             <p class="text-xs">Messages</p>
           </router-link>
         </div>

--- a/src/components/Profile/Edit/DataCompletionStatus.vue
+++ b/src/components/Profile/Edit/DataCompletionStatus.vue
@@ -8,7 +8,7 @@
           Hai, <b>{{user.name}}</b>!
           <button class="appearance-none absolute right-0"
                   @click.capture="showStatus = false">
-            <i class="fas fa-times fa-lg text-gray-600 hover:text-red-400"></i>
+            <i aria-hidden="true" class="fas fa-times fa-lg text-gray-600 hover:text-red-400"></i>
           </button>
         </h3>
         <template v-if="completionPercentage >= 100">
@@ -23,7 +23,7 @@
                             to="/profile/edit/personal"
                             class="font-bold text-brand-blue hover:text-blue-900 hover:underline">sini</router-link>
               <span v-else>sini</span>
-              &nbsp;&nbsp;<i class="far fa-smile"></i>
+              &nbsp;&nbsp;<i aria-hidden="true" class="far fa-smile"></i>
             </p>
             <br>
             <figcaption class="max-w-sm">
@@ -31,7 +31,8 @@
                 Seberapa lengkap data kamu?
               </caption>
               <div class="w-full flex flex-row items-center">
-                <i  role="progress bar"
+                <i  aria-hidden="true"
+                    role="progress bar"
                     class="progress-bar flex-1"
                     :style="progressBarStyle">
                 </i>

--- a/src/components/Profile/Edit/ProfileSectionDetail.vue
+++ b/src/components/Profile/Edit/ProfileSectionDetail.vue
@@ -4,7 +4,7 @@
       <template #pending>
         <div class="w-full h-full flex justify-center items-center bg-gray-200"
              style="min-height: 200px;">
-          <i class="app-logo is-rounded is-beating"></i>
+          <i aria-hidden="true" class="app-logo is-rounded is-beating"></i>
         </div>
       </template>
       <template #error="{error}">

--- a/src/components/Profile/Edit/ProfileSectionList.vue
+++ b/src/components/Profile/Edit/ProfileSectionList.vue
@@ -9,6 +9,7 @@
           :class="['profile-section-list__item', isSectionActive(sect) && 'is-active']"
           @click.capture="$emit('click', sect)">
         <i v-if="isSectionActive(sect)"
+           aria-hidden="true"
            class="inline-block align-baseline w-3 h-3 mr-2 rounded-full bg-brand-yellow-darkest"></i>
         <span class="inline align-baseline font-bold"
               style="color: currentColor">

--- a/src/components/ThankYouList.vue
+++ b/src/components/ThankYouList.vue
@@ -5,7 +5,7 @@
         <div v-for="item in items" :key="item.id" class="w-full bg-white shadow p-4 px-6">
           <div class="flex">
             <div class="flex items-center block mx-auto mr-4">
-              <i class="fas fa-heart text-red-500 text-lg" />
+              <i aria-hidden="true" class="fas fa-heart text-red-500 text-lg" />
             </div>
             <div class="text-left flex-grow">
               <p class="text-sm leading-normal">{{ item['message'] }}</p>

--- a/src/views/ArticleDetail.vue
+++ b/src/views/ArticleDetail.vue
@@ -9,7 +9,7 @@
         <template v-if="!loading">
           <div class="flex">
             <div class="flex items-center block mx-auto mr-4">
-              <i class="fas fa-check-circle text-brand-green text-lg" />
+              <i aria-hidden="true" class="fas fa-check-circle text-brand-green text-lg" />
             </div>
             <div class="text-left flex-grow">
               <p class="text-sm leading-normal">{{ item['title'] }}</p>

--- a/src/views/Booking.vue
+++ b/src/views/Booking.vue
@@ -3,7 +3,7 @@
     <div class="container mx-auto">
       <div class="w-full pt-4">
         <div class="text-center">
-          <i class="far fa-4x fa-building mb-4 text-gray-600" />
+          <i aria-hidden="true" class="far fa-4x fa-building mb-4 text-gray-600" />
           <p class="text-sm">Reservasi Ruangan Rapat</p>
         </div>
 

--- a/src/views/Checkins.vue
+++ b/src/views/Checkins.vue
@@ -4,7 +4,7 @@
       <template v-if="!user">
         <div class="w-full pt-4">
           <div class="text-center">
-            <i class="far fa-4x fa-check-circle mb-4 text-gray-600" />
+            <i aria-hidden="true" class="far fa-4x fa-check-circle mb-4 text-gray-600" />
             <p class="text-sm">Silahkan login untuk melakukan checkin.</p>
           </div>
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -12,7 +12,7 @@
             <template v-if="!user">
               <div class="w-full pt-4 text-center">
                 <div class="">
-                  <i class="far fa-4x fa-check-circle mb-4 text-gray-600" />
+                  <i aria-hidden="true" class="far fa-4x fa-check-circle mb-4 text-gray-600" />
                   <p class="text-sm">Silahkan login terlebih dahulu</p>
                 </div>
                 <div class="mx-2 my-2">
@@ -27,7 +27,7 @@
               <div v-for="(m, index) in menuItems" :key="index" class="w-1/3">
                 <component :is="getMenuLinkComponent(m)" v-bind="getMenuLinkProps(m)" >
                   <div class="h-full p-3 py-4 text-center text-gray-700">
-                    <i :class="[m.icon, 'text-2xl'] " />
+                    <i aria-hidden="true" :class="[m.icon, 'text-2xl'] " />
                     <p class="text-xs mt-1">{{m.name}}</p>
                   </div>
                 </component>

--- a/src/views/Logbook/Detail.vue
+++ b/src/views/Logbook/Detail.vue
@@ -7,7 +7,7 @@
       <button
         class="cursor-pointer text-sm px-4 py-1 rounded-full text-brand-green border border-solid border-brand-green hover:bg-green-100"
         @click="onEdit">
-        <i class="fa fa-pencil-alt mr-2"></i>
+        <i aria-hidden="true" class="fa fa-pencil-alt mr-2"></i>
         <b class="uppercase">
           Edit
         </b>

--- a/src/views/MessageDetail.vue
+++ b/src/views/MessageDetail.vue
@@ -9,7 +9,7 @@
         <template v-if="!loading">
           <div class="flex">
             <div class="flex items-center block mx-auto mr-4">
-              <i class="fas fa-envelope text-brand-green text-lg" />
+              <i aria-hidden="true" class="fas fa-envelope text-brand-green text-lg" />
             </div>
             <div class="text-left flex-grow">
               <p class="text-sm leading-normal">{{ item['title'] }}</p>

--- a/src/views/ThankYou.vue
+++ b/src/views/ThankYou.vue
@@ -3,7 +3,14 @@
     <div class="container mx-auto">
       <div class="flex flex-wrap">
         <div class="w-full mx-2 my-2">
-          <router-link to="/thankyou/create" class="w-full text-center shadow block bg-brand-blue text-white font-bold py-2 px-4 rounded">Kirim Terimakasih <i class="ml-2 fas fa-heart text-red-500 text-lg" /></router-link>
+          <router-link
+            to="/thankyou/create"
+            class="w-full text-center shadow block bg-brand-blue text-white font-bold py-2 px-4 rounded">
+            Kirim Terimakasih
+            <i
+              aria-hidden="true"
+              class="ml-2 fas fa-heart text-red-500 text-lg" />
+          </router-link>
         </div>
       </div>
       <thank-you-list class="mt-2" />

--- a/src/views/UnderConstruction.vue
+++ b/src/views/UnderConstruction.vue
@@ -3,7 +3,7 @@
     <div class="container mx-auto">
       <div class="w-full pt-4">
         <div class="text-center">
-          <i class="far fa-4x fa-sad-tear mb-4 text-gray-600" />
+          <i aria-hidden="true" class="far fa-4x fa-sad-tear mb-4 text-gray-600" />
           <p class="text-sm">Fitur ini belum ada yang coding. Bantu dong. <br />Tulis feedback dan fitur dibutuhkan + vote gan.</p>
         </div>
 


### PR DESCRIPTION
#### Changes:
- change `<i>` tags used for italic formatting with `<em>`.
- change `<i>` tags used for skeleton styling with `<em>`.
- keep `<i>` tags used for FontAwesome icon placeholders, and add `aria-hidden=true` attribute as form of compliant.