### PR TITLE
Ensure SonarQube action script is run on each PR event

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -2,8 +2,10 @@ on:
   push:
     branches:
       - master
-    pull_request:
-      types: [assigned, opened, synchronize, reopened]
+  pull_request:
+    branches:
+      - master
+    types: [opened, synchronize, reopened]
 name: Run SonarCloud Scan
 jobs:
   sonarcloud:


### PR DESCRIPTION
#### Changes
- Previously, SonarQube Github Action only run on merged to branch master. Now, action will be run for each PR with base branch master. Included PR event: `opened`, `synchronized`, `reopened`.

#### Notes
- `opened` event: For each newly created PR. 
- `synchronized` event: https://github.community/t/what-is-a-pull-request-synchronize-event/14784
- `reopened` event: For each reopened PR.

#### Extra
Action can be seen below (above netlify hooks).
![image](https://user-images.githubusercontent.com/20709202/111599276-b2711680-8802-11eb-8df6-f1eea711e03c.png)
