### PR TITLE
remove unneeded <img> tag previously used for user profile picture

### DIFF
--- a/src/components/CheckinsList.vue
+++ b/src/components/CheckinsList.vue
@@ -5,8 +5,6 @@
         <template v-if="items.length > 0">
           <div v-for="item in items" :key="item.id" class="w-full bg-white shadow p-4 px-6" :class="getRowClass(item)">
             <div class="flex items-center">
-              <img alt="User Profile Picture" class="w-10 h-10 rounded-full mr-4" :src="item['user_photo']" />
-
               <div class="flex-auto text-sm">
                 <p class="text-gray-900 font-bold">
                     {{ item['fullname'] }}


### PR DESCRIPTION
### Why
1) API response for attendance contains no user profile picture data/url.
2) Previously, this is not a problem since nothing is shown when `src` attribute equals `null` or `undefined`.
3) Problem arise right after `alt` attribute is set for `<img>` tag:
![image](https://user-images.githubusercontent.com/20709202/112427358-0bddc600-8d6c-11eb-91cd-72b11b0b1faa.png)

### Fixes
- Remove unneeded `<img>` tag.

### Result
![image](https://user-images.githubusercontent.com/20709202/112427457-3465c000-8d6c-11eb-8b30-1d9343f77504.png)
