### PR TITLE
Ensure attachment is only mandatory for item outside of "Diluar Tupoksi Jabatan" 

### DIFF
--- a/src/components/FormLogbook/InputLink.vue
+++ b/src/components/FormLogbook/InputLink.vue
@@ -7,8 +7,8 @@
     :title="inputTitle"
     placeholder="https://"
     :disabled="showAsReadonlyLink"
-    :required="required"
-    :rules="{ required, regex: /^https?:\/\//}"
+    :required="isLinkRequired"
+    :rules="{ required: isLinkRequired, regex: /^https?:\/\//}"
     :custom-messages="{
       required: 'Lampiran hasil kerja harus diisi',
       regex: 'Lampiran hasil kerja harus dalam bentuk URL yang valid'
@@ -31,7 +31,7 @@
     <FormInputHeader
       :label-for="inputName"
       :title="inputTitle"
-      :required="required"
+      :required="isLinkRequired"
     >
     </FormInputHeader>
     <div class="form-input-link__wrapper">
@@ -74,6 +74,7 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
 import FormInput from '../Form/Input'
 import FormInputHeader from '../Form/InputHeader'
 export default {
@@ -86,6 +87,9 @@ export default {
     event: 'change'
   },
   props: {
+    tupoksiId: {
+      type: String
+    },
     value: {
       type: [String, Number],
       default: ''
@@ -93,10 +97,6 @@ export default {
     showAsReadonlyLink: {
       type: Boolean,
       default: false
-    },
-    required: {
-      type: Boolean,
-      default: true
     }
   },
   data () {
@@ -112,6 +112,21 @@ export default {
     }
   },
   computed: {
+    ...mapState('organizations', [
+      'listOfTupoksi'
+    ]),
+    isLinkRequired () {
+      const { listOfTupoksi } = this
+      if (!Array.isArray(listOfTupoksi) || !listOfTupoksi.length) {
+        return false
+      }
+      /**
+       * NOTE: it is confirmed that last element of query result
+       * will always represent "Diluar tupoksi jabatan" item
+       */
+      const lastElement = listOfTupoksi[listOfTupoksi.length - 1]
+      return this.tupoksiId !== lastElement.id
+    },
     syncedValue: {
       get () {
         return this.value

--- a/src/components/FormLogbook/InputLink.vue
+++ b/src/components/FormLogbook/InputLink.vue
@@ -7,7 +7,8 @@
     :title="inputTitle"
     placeholder="https://"
     :disabled="showAsReadonlyLink"
-    :rules="{ required: true, regex: /^https?:\/\//}"
+    :required="required"
+    :rules="{ required, regex: /^https?:\/\//}"
     :custom-messages="{
       required: 'Lampiran hasil kerja harus diisi',
       regex: 'Lampiran hasil kerja harus dalam bentuk URL yang valid'
@@ -30,7 +31,7 @@
     <FormInputHeader
       :label-for="inputName"
       :title="inputTitle"
-      :required="true"
+      :required="required"
     >
     </FormInputHeader>
     <div class="form-input-link__wrapper">
@@ -92,6 +93,10 @@ export default {
     showAsReadonlyLink: {
       type: Boolean,
       default: false
+    },
+    required: {
+      type: Boolean,
+      default: true
     }
   },
   data () {

--- a/src/components/FormLogbook/index.vue
+++ b/src/components/FormLogbook/index.vue
@@ -90,7 +90,8 @@
         ref="formInputDocumentLink"
         :show-as-readonly-link="!isEditable"
         :tupoksi-id="payload.tupoksiJabatanId"
-        v-model="documentTaskLink"
+        :value="documentTaskLink"
+        @change="onDocumentTaskLinkChanged"
       />
       <br />
       <FormInput
@@ -242,11 +243,8 @@ export default {
         }
         const { documentTaskURL } = logbook
         this.originalData = _cloneDeep(logbook)
-        this.payload = {
-          ...logbook,
-          isDocumentLink: true
-        }
-        this.documentTaskLink = documentTaskURL
+        this.payload = logbook
+        this.onDocumentTaskLinkChanged(documentTaskURL)
       }
     }
   },
@@ -277,6 +275,16 @@ export default {
       if (opt) {
         this.$set(this.payload, 'projectId', opt.id)
         this.$set(this.payload, 'projectName', opt.name)
+      }
+    },
+    onDocumentTaskLinkChanged (link) {
+      this.documentTaskLink = link
+      if (typeof link !== 'string' || !link.length) {
+        this.payload.isDocumentLink = false
+        this.documentTaskLink = null
+      } else {
+        this.payload.isDocumentLink = /^https?:\/\//.test(link)
+        this.documentTaskLink = link
       }
     },
     onCancel () {

--- a/src/components/FormLogbook/index.vue
+++ b/src/components/FormLogbook/index.vue
@@ -47,8 +47,7 @@
       <FormInputTupoksi
         name="tupoksiJabatanId"
         :show-as-readonly-input="isViewingOnly"
-        v-model="payload.tupoksiJabatanId"
-        @change="onTupoksiJabatanChanged" />
+        v-model="payload.tupoksiJabatanId" />
       <br />
       <FormInputDateTime
         name="dateTask"
@@ -90,7 +89,7 @@
       <FormInputLink
         ref="formInputDocumentLink"
         :show-as-readonly-link="!isEditable"
-        :required="isDocumentTaskLinkMandatory"
+        :tupoksi-id="payload.tupoksiJabatanId"
         v-model="documentTaskLink"
       />
       <br />
@@ -211,7 +210,6 @@ export default {
       originalData: null,
       payload: Object.assign({}, modelData),
       documentTaskLink: null,
-      isDocumentTaskLinkMandatory: false,
 
       maxDateTime: new Date().toISOString()
     }
@@ -242,10 +240,13 @@ export default {
           this.$emit('logbook:not-found', id)
           return
         }
-        const { documentTaskURL, isDocumentLink } = logbook
+        const { documentTaskURL } = logbook
         this.originalData = _cloneDeep(logbook)
-        this.payload = logbook
-        this.documentTaskLink = isDocumentLink ? documentTaskURL : null
+        this.payload = {
+          ...logbook,
+          isDocumentLink: true
+        }
+        this.documentTaskLink = documentTaskURL
       }
     }
   },
@@ -278,18 +279,6 @@ export default {
         this.$set(this.payload, 'projectName', opt.name)
       }
     },
-    onTupoksiJabatanChanged (tupoksiJabatanId) {
-      const { listOfTupoksi } = this.$store.state.organizations
-      if (!Array.isArray(listOfTupoksi) || !listOfTupoksi.length) {
-        return
-      }
-      /**
-       * NOTE: it is confirmed that last element of query result
-       * will always represent "Diluar tupoksi jabatan" item
-       */
-      const lastElement = listOfTupoksi[listOfTupoksi.length - 1]
-      this.isDocumentTaskLinkMandatory = tupoksiJabatanId !== lastElement.id
-    },
     onCancel () {
       if (typeof this.onCancelCallback === 'function') {
         return this.onCancelCallback()
@@ -313,7 +302,7 @@ export default {
       try {
         const evidenceFile = this.$refs.formInputEvidence.getSelectedFile()
         formData.append('evidenceTask', evidenceFile)
-        formData.append('documentTask', this.documentTaskLink)
+        formData.append('documentTask', this.documentTaskLink || '')
         return formData
       } catch (e) {
         return null
@@ -342,7 +331,7 @@ export default {
       try {
         const evidenceFile = this.$refs.formInputEvidence.getSelectedFile()
         formData.append('evidenceTask', evidenceFile)
-        formData.append('documentTask', this.documentTaskLink)
+        formData.append('documentTask', this.documentTaskLink || '')
         return formData
       } catch (e) {
         return null

--- a/src/components/FormLogbook/index.vue
+++ b/src/components/FormLogbook/index.vue
@@ -47,7 +47,8 @@
       <FormInputTupoksi
         name="tupoksiJabatanId"
         :show-as-readonly-input="isViewingOnly"
-        v-model="payload.tupoksiJabatanId" />
+        v-model="payload.tupoksiJabatanId"
+        @change="onTupoksiJabatanChanged" />
       <br />
       <FormInputDateTime
         name="dateTask"
@@ -89,6 +90,7 @@
       <FormInputLink
         ref="formInputDocumentLink"
         :show-as-readonly-link="!isEditable"
+        :required="isDocumentTaskLinkMandatory"
         v-model="documentTaskLink"
       />
       <br />
@@ -209,6 +211,7 @@ export default {
       originalData: null,
       payload: Object.assign({}, modelData),
       documentTaskLink: null,
+      isDocumentTaskLinkMandatory: false,
 
       maxDateTime: new Date().toISOString()
     }
@@ -274,6 +277,18 @@ export default {
         this.$set(this.payload, 'projectId', opt.id)
         this.$set(this.payload, 'projectName', opt.name)
       }
+    },
+    onTupoksiJabatanChanged (tupoksiJabatanId) {
+      const { listOfTupoksi } = this.$store.state.organizations
+      if (!Array.isArray(listOfTupoksi) || !listOfTupoksi.length) {
+        return
+      }
+      /**
+       * NOTE: it is confirmed that last element of query result
+       * will always represent "Diluar tupoksi jabatan" item
+       */
+      const lastElement = listOfTupoksi[listOfTupoksi.length - 1]
+      this.isDocumentTaskLinkMandatory = tupoksiJabatanId !== lastElement.id
     },
     onCancel () {
       if (typeof this.onCancelCallback === 'function') {


### PR DESCRIPTION
### Task Description
Link attachment is not mandatory when selected tupoksi equals "Diluar tupoksi jabatan".

### Changes
- Supply selected "tupoksi jabatan" Id as props for `<InputLink/>` component
- Determine attachment mandatory check within `<InputLink />` component
- Use manual binding (`:value` and `@change`) for  `<InputLink />` component