### PR TITLE
Ensure page is refreshable when viewing logbook

### DIFF
--- a/src/components/FormLogbook/Skeleton.vue
+++ b/src/components/FormLogbook/Skeleton.vue
@@ -8,11 +8,5 @@
 </template>
 
 <script>
-export default {
-
-}
+export default {}
 </script>
-
-<style>
-
-</style>

--- a/src/components/FormLogbook/Skeleton.vue
+++ b/src/components/FormLogbook/Skeleton.vue
@@ -1,0 +1,18 @@
+<template>
+  <div>
+    <div v-for="i in 5" :key="i">
+      <i aria-hidden="true" class="block w-24 h-6 mb-2 rounded-sm bg-shimmering" />
+      <i aria-hidden="true" class="block w-full h-10 mb-8 rounded-sm bg-shimmering" />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style>
+
+</style>

--- a/src/components/FormLogbook/index.vue
+++ b/src/components/FormLogbook/index.vue
@@ -252,18 +252,19 @@ export default {
   },
   methods: {
     async getLogbook (id) {
+      let logbook = null
       this.isLoadingLogbook = true
       try {
-        let logbook = await this.getLogbookFromVuex(id)
+        logbook = await this.getLogbookFromVuex(id)
         if (!logbook) {
           logbook = await this.getLogbookFromDatabase(id)
         }
-        return logbook
       } catch (e) {
-        return null
+        logbook = null
       } finally {
         this.isLoadingLogbook = false
       }
+      return logbook
     },
     getLogbookFromVuex (id) {
       const logbook = this.$store.state['logbook-list'].logbookInView

--- a/src/components/FormLogbook/index.vue
+++ b/src/components/FormLogbook/index.vue
@@ -275,8 +275,12 @@ export default {
       }
       return Promise.resolve(null)
     },
-    getLogbookFromDatabase (id) {
-      return this.$store.dispatch('logbook-list/getLogbookById', { id })
+    async getLogbookFromDatabase (id) {
+      const logbook = await this.$store.dispatch('logbook-list/getLogbookById', { id })
+      if (logbook) {
+        this.$store.commit('logbook-list/setLogbookInView', logbook)
+      }
+      return logbook
     },
     resetPayload () {
       this.payload = Object.assign({}, modelData)

--- a/src/store/modules/logbook-list.js
+++ b/src/store/modules/logbook-list.js
@@ -28,6 +28,28 @@ export const actions = {
     }
     return GroupwareAPI.get(`logbook/${id}`)
       .then(r => r.data)
+      .then((logbook) => {
+        const {
+          documentTask = {},
+          evidenceTask = {},
+          blobTask,
+          createdBy,
+          updatedBy,
+          __v,
+          ...rest
+        } = logbook
+
+        return Object.assign(
+          {},
+          rest,
+          {
+            documentTaskPath: documentTask.filePath,
+            documentTaskURL: documentTask.fileURL,
+            evidenceTaskPath: evidenceTask.filePath,
+            evidenceTaskURL: evidenceTask.fileURL
+          }
+        )
+      })
   },
   insertLogbook (_, payload) {
     return GroupwareAPI.post('/logbook/', payload)


### PR DESCRIPTION
### Task Description
Logbook view, e.g `/#/report/detail?id=60752fae5cc9120011d2c5f0` is currently not refreshable. Refreshing such page would result in blank form.

### Changes
- Implement `/logbook/:id` API endpoint. Ensure response is matched with `/logbook` so no further processing required.
- Create loading hint on page enter or refreshed