### PR TITLE
add id to sorting rule on fetching paginated logbook data

### DIFF
--- a/src/store/modules/logbook-list.js
+++ b/src/store/modules/logbook-list.js
@@ -16,7 +16,7 @@ export const actions = {
   async getLogbookList ({ state, commit }, params = {}) {
     const get = await GroupwareAPI.get('/logbook/', {
       params: {
-        sort: 'dateTask',
+        sort: 'dateTask,_id',
         ...params
       }
     }).then(r => r.data)


### PR DESCRIPTION
### Related Task
[[BUGS] Paging data daftar laporan tidak sesuai dengan urutan. Ada beberapa task yang ada di page A, namun masih masuk ke page selanjutnya (page B)](https://app.clickup.com/t/7ttkah)

### Changes
- add `_id` to sorting rule