### PR TITLE
Set profile picture fallback on google assets throws error

### DIFF
--- a/src/components/UserInfo.vue
+++ b/src/components/UserInfo.vue
@@ -9,7 +9,8 @@
           <img
             alt="User Avatar"
             class="object-cover object-center w-16 h-16 rounded-full mr-4"
-            :src="user.photo || AVATAR_PLACEHOLDER">
+            :src="user.photo || AVATAR_PLACEHOLDER"
+            @error="onImageError">
           <div class="inline-block flex-auto">
             <strong class="block text-gray-900 text-lg leading-normal">{{ user.fullname }}</strong>
             <p class="text-gray-600 text-sm">{{ user.jabatan }}</p>
@@ -48,6 +49,9 @@ export default {
       } finally {
         this[UNAUTHENTICATED]()
       }
+    },
+    onImageError (e) {
+      e.target.src = this.AVATAR_PLACEHOLDER
     }
   }
 }


### PR DESCRIPTION
### Task Description
_As described in PR title_.

### Changes
Set profpic fallback to default avatar placeholder on image request error.

### Preview
On Success
![Screenshot from 2021-04-29 07 51 06](https://user-images.githubusercontent.com/20709202/116489667-b3946980-a8bf-11eb-8d3b-044eacca92de.png)

On Error
![Screenshot from 2021-04-29 07 50 47](https://user-images.githubusercontent.com/20709202/116489660-b000e280-a8bf-11eb-9c64-959d09e33a85.png)
