### PR TITLE
Fix user journey on editing logbook/report

### DIFF
--- a/src/components/FormLogbook/index.vue
+++ b/src/components/FormLogbook/index.vue
@@ -374,9 +374,7 @@ export default {
         showCancelButton: false,
         confirmButtonText: 'Tutup'
       }).then(() => {
-        this.$router.push({
-          path: '/report'
-        })
+        this.$router.back()
       })
     },
     onError (msg) {

--- a/src/components/LogbookList/index.vue
+++ b/src/components/LogbookList/index.vue
@@ -1,6 +1,7 @@
 <template>
   <ResponsiveComponentLoader
     v-bind="$attrs"
+    v-on="$listeners"
     for-desktop="LogbookList/table.vue"
     for-mobile="LogbookList/card-list.vue" />
 </template>

--- a/src/components/LogbookList/index.vue
+++ b/src/components/LogbookList/index.vue
@@ -1,5 +1,8 @@
 <template>
-  <ResponsiveComponentLoader for-desktop="LogbookList/table.vue" for-mobile="LogbookList/card-list.vue" />
+  <ResponsiveComponentLoader
+    v-bind="$attrs"
+    for-desktop="LogbookList/table.vue"
+    for-mobile="LogbookList/card-list.vue" />
 </template>
 
 <script>

--- a/src/components/LogbookList/table.vue
+++ b/src/components/LogbookList/table.vue
@@ -69,6 +69,7 @@ import VPagination from 'vuejs-paginate'
 import listMixin from './list-mixin'
 import DateRangePicker from './date-range-picker.vue'
 import TableRow from './table-row'
+import _isEqual from 'lodash/isEqual'
 
 export default {
   name: 'LogbookTable',
@@ -77,6 +78,12 @@ export default {
     VPagination,
     TableRow,
     DateRangePicker
+  },
+  props: {
+    query: {
+      type: Object,
+      default: () => null
+    }
   },
   data () {
     return {
@@ -123,8 +130,28 @@ export default {
       }
     }
   },
-  created () {
-    this.loadData()
+  watch: {
+    query: {
+      immediate: true,
+      deep: true,
+      handler (newObject, oldObject) {
+        if (_isEqual(newObject, oldObject)) {
+          return
+        }
+
+        const {
+          page,
+          perPage,
+          start_date: startDate,
+          end_date: endDate
+        } = (newObject || {})
+        this.page = page || 1
+        this.perPage = perPage || 10
+        this.startDate = startDate
+        this.endDate = endDate
+        this.loadData()
+      }
+    }
   },
   methods: {
     onDateChanged ({ start_date: startDate, end_date: endDate }) {

--- a/src/components/LogbookList/table.vue
+++ b/src/components/LogbookList/table.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
-    <DateRangePicker @change-date="onDateChanged"/>
+    <DateRangePicker
+      :range="dateRange"
+      @change-date="onDateChanged"/>
       <div class="v-pagination-container">
         <VPagination v-bind="pagination" />
       </div>
@@ -34,7 +36,7 @@
           </thead>
           <tbody>
             <template v-if="isLoadingLogbookList">
-              <tr v-for="i in perPage" :key="`skeleton:${i}`">
+              <tr v-for="i in mQuery.perPage" :key="`skeleton:${i}`">
                 <td v-for="j in 8" :key="`col:${j}`" class="p-4">
                   <div class="w-full h-2 rounded-full bg-shimmering" />
                 </td>
@@ -92,22 +94,34 @@ export default {
       logbookListData: null,
       totalPage: 0,
       totalCount: 0,
-      page: 1,
-      perPage: 10,
-      startDate: null,
-      endDate: null
+
+      mQuery: {
+        page: 1,
+        perPage: 10,
+        startDate: null,
+        endDate: null
+      }
     }
   },
   computed: {
+    dateRange () {
+      const { startDate, endDate } = this.mQuery
+      const start = startDate ? new Date(startDate) : null
+      const end = endDate ? new Date(endDate) : null
+      return {
+        start,
+        end
+      }
+    },
     startIndex () {
       if (this.totalCount) {
-        return (this.page - 1) * (this.perPage)
+        return (this.mQuery.page - 1) * (this.mQuery.perPage)
       }
       return 0
     },
     endIndex () {
       if (this.totalCount) {
-        if (this.page === Math.ceil(this.totalCount / this.perPage)) {
+        if (this.mQuery.page === Math.ceil(this.totalCount / this.mQuery.perPage)) {
           return this.totalCount - 1
         } else {
           return this.startIndex + this.logbookListData.length - 1
@@ -117,7 +131,7 @@ export default {
     },
     pagination () {
       return {
-        value: this.page,
+        value: this.mQuery.page,
         pageCount: this.totalPage,
         pageRange: 3,
         containerClass: 'v-pagination',
@@ -140,36 +154,69 @@ export default {
         }
 
         const {
+          page = 1,
+          perPage = 10,
+          startDate = null,
+          endDate = null
+        } = (newObject || {})
+        this.updateQuery({
           page,
           perPage,
-          start_date: startDate,
-          end_date: endDate
-        } = (newObject || {})
-        this.page = page || 1
-        this.perPage = perPage || 10
-        this.startDate = startDate
-        this.endDate = endDate
-        this.loadData()
+          startDate,
+          endDate
+        }, {
+          sync: false
+        })
       }
     }
   },
   methods: {
+    updateQuery ({
+      page,
+      perPage,
+      startDate,
+      endDate
+    }, {
+      sync = true
+    } = {}) {
+      this.mQuery = {
+        page,
+        perPage,
+        startDate,
+        endDate
+      }
+      if (sync) {
+        this.$emit('update:query', this.mQuery)
+      }
+      this.loadData()
+    },
+    getQueryAsAPISpec () {
+      const { page, perPage, startDate, endDate } = this.mQuery
+      return {
+        page,
+        pageSize: perPage,
+        start_date: startDate,
+        end_date: endDate
+      }
+    },
     onDateChanged ({ start_date: startDate, end_date: endDate }) {
-      this.page = 1
+      this.updateQuery({
+        perPage: this.mQuery.perPage,
+        page: 1,
+        startDate,
+        endDate
+      })
       this.totalCount = 0
       this.totalPage = 0
-      this.startDate = startDate
-      this.endDate = endDate
-      this.loadData()
     },
     onPageChanged (newPage) {
-      this.page = newPage
-      this.loadData()
+      this.updateQuery({
+        ...this.mQuery,
+        page: newPage
+      })
     },
     onLoadSuccess ({ results, _meta }) {
-      const { currentPage, perPage, totalPage, totalCount } = _meta
-      this.page = currentPage
-      this.perPage = perPage
+      const { totalPage, totalCount } = _meta
       this.totalPage = totalPage
       this.totalCount = totalCount
       this.logbookListData = results
@@ -184,12 +231,9 @@ export default {
       this.isLoadingLogbookList = true
       this.logbookListError = null
 
-      this.$store.dispatch('logbook-list/getLogbookList', {
-        page: this.page,
-        pageSize: this.perPage,
-        start_date: this.startDate,
-        end_date: this.endDate
-      }).then(this.onLoadSuccess)
+      const params = this.getQueryAsAPISpec()
+      this.$store.dispatch('logbook-list/getLogbookList', params)
+        .then(this.onLoadSuccess)
         .catch(this.onLoadError)
         .finally(this.onLoadFinished)
     }

--- a/src/components/ResponsiveComponentLoader/index.js
+++ b/src/components/ResponsiveComponentLoader/index.js
@@ -66,7 +66,8 @@ export default {
   render (h) {
     if (this.component) {
       return h(this.component, {
-        props: this.$attrs || {}
+        props: this.$attrs || {},
+        on: this.$listeners
       })
     }
     return null

--- a/src/components/ResponsiveComponentLoader/index.js
+++ b/src/components/ResponsiveComponentLoader/index.js
@@ -65,7 +65,9 @@ export default {
   },
   render (h) {
     if (this.component) {
-      return h(this.component)
+      return h(this.component, {
+        props: this.$attrs || {}
+      })
     }
     return null
   }

--- a/src/lib/querystring-parser.js
+++ b/src/lib/querystring-parser.js
@@ -1,0 +1,50 @@
+import _omitBy from 'lodash/omitBy'
+import _isNil from 'lodash/isNil'
+
+const defaultParserOptions = {
+  omitNil: true
+}
+
+/**
+ * Parse stringified query in window.location.search into VueRouter#query.
+ * Used to construct VueRouter#query object
+ * only when user perform full page request whose URL contains querystring.
+ *
+ * @example
+ * const queryString = { page: "1" }
+ * const parsed = parseQuery(queryString, { page: Number })
+ * // Expected output
+ * { page: 1 }
+ */
+function parseQuery (routeQuery, querySchema, options = defaultParserOptions) {
+  if (!routeQuery || !Object.keys(routeQuery).length) {
+    return undefined
+  }
+
+  // remove nil values (null or undefined)
+  const source = options.omitNil
+    ? _omitBy(routeQuery, _isNil)
+    : routeQuery
+
+  const result = Object
+    .entries(source)
+    .reduce((obj, [key, value]) => {
+      const ctor = querySchema[key]
+      if (typeof ctor === 'function') {
+        // construct property value using provided schema
+        // e.g. Number('1') => 1
+        obj[key] = ctor(value)
+      } else {
+        // use raw querystring value if constructor for this key
+        // is not provided
+        obj[key] = value
+      }
+      return obj
+    }, {})
+
+  return result
+}
+
+export {
+  parseQuery
+}

--- a/src/views/Logbook/List.vue
+++ b/src/views/Logbook/List.vue
@@ -21,11 +21,15 @@
         </a>
       </div>
     </div>
-    <LogbookList :query="logbookListQuery" />
+    <LogbookList
+      :query="logbookListQuery"
+      @update:query="onLogbookListQueryUpdated" />
   </div>
 </template>
 
 <script>
+import _omitBy from 'lodash/omitBy'
+import _isNil from 'lodash/isNil'
 import { parseQuery } from '../../lib/querystring-parser'
 
 export default {
@@ -45,10 +49,19 @@ export default {
       handler (newObject) {
         this.logbookListQuery = parseQuery(newObject, {
           page: Number,
-          start_date: String,
-          end_date: String
+          startDate: String,
+          endDate: String
         })
       }
+    }
+  },
+  methods: {
+    onLogbookListQueryUpdated (newQuery) {
+      this.$router.push({
+        query: _omitBy(newQuery, _isNil)
+      }).catch(() => {
+        // silent error
+      })
     }
   },
   beforeRouteEnter (to, from, next) {

--- a/src/views/Logbook/List.vue
+++ b/src/views/Logbook/List.vue
@@ -26,7 +26,7 @@
 </template>
 
 <script>
-import { parseQuery } from '../../lib/pagination-query-utils'
+import { parseQuery } from '../../lib/querystring-parser'
 
 export default {
   components: {

--- a/src/views/Logbook/List.vue
+++ b/src/views/Logbook/List.vue
@@ -21,18 +21,34 @@
         </a>
       </div>
     </div>
-    <LogbookList/>
+    <LogbookList :query="logbookListQuery" />
   </div>
 </template>
 
 <script>
+import { parseQuery } from '../../lib/pagination-query-utils'
+
 export default {
   components: {
     LogbookList: () => import('../../components/LogbookList')
   },
   data () {
     return {
-      showDetail: true
+      showDetail: true,
+      logbookListQuery: null
+    }
+  },
+  watch: {
+    '$route.query': {
+      immediate: true,
+      deep: true,
+      handler (newObject) {
+        this.logbookListQuery = parseQuery(newObject, {
+          page: Number,
+          start_date: String,
+          end_date: String
+        })
+      }
     }
   },
   beforeRouteEnter (to, from, next) {


### PR DESCRIPTION
### Task Description
Saat ini, saat user selesai mengedit laporan, maka list laporan akan selalu kembali ke halaman 1 terlepas dari halaman mana user masuk. Hal ini mengakibatkan user harus kembali ke halaman mula, jika user hendak mengedit laporan lainnya yang letaknya berdekatan.

#### Challenges:
A) Untuk mencapai _behavior_ di atas, nilai dari _query_ bernama _page_ harus disimpan ke dalam suatu state management, bukan hanya di-_supply_ sebagai _query_ ke dalam axios, sehingga kita memiliki referensi ke halaman mana user harus dikembalikan.
B) Setiap kali user me-_refresh_ (F5) halaman, nilai yang tersimpan pada VueRouter#query adalah hasil `stringify` dari [`window.location.search`](https://developer.mozilla.org/en-US/docs/Web/API/Location/search), dimana _query_ berbentuk `?page=1` akan terbaca sebagai `{ page: "1"}`, ketimbang `{ page: 1 }`.

### Proposed Solution
#### Challenge A
- _Browser history_ sudah memiliki [_state management_,](https://developer.mozilla.org/en-US/docs/Web/API/History_API) sehingga kita cukup memanfaatkan fitur [`VueRouter#back`](https://router.vuejs.org/guide/essentials/navigation.html), tanpa harus me-maintain rute secara manual (misalnya dalam Vuex).  _Query_ tidak langsung di-_supply_ kepada axios, namun disimpan dan hanya disimpan ke dalam rute. Lalu _router view_ melakukan _watch_ terhadap `route.query` dimaksud, dimana setiap perubahan akan men-_trigger_ pemanggilan data yang baru oleh axios. Hal ini baiknya juga dilakukan untuk _query field_ lainnya selain _page_.

#### Challenge B
- Membuat _parser_ untuk _query_ hasil _stringify_, dimana developer dapat men-_supply_ skema dari _query_ tersebut.

### Proof of Concept
Berikut contoh hasil penyimpanan _query_ dalam rute, dimana user tidak kembali ke halaman 1 setelah melakukan edit, melainkan ke halaman mula dimana user masuk.

![Screen record from 2021-05-18 16 17 38](https://user-images.githubusercontent.com/20709202/118625907-9e429900-b7f4-11eb-9618-7e918cad62a3.gif)

### Todo
- [x] Membuat query parser
- [x] Melakukan watch terhadap route.query pada router view
- [x] Membuat component list laporan reaktif terhadap perubahan rute
- [x] Memastikan fungsionalitas berjalan pada viewport desktop
- [ ] Memastikan fungsionalitas berjalan pada viewport mobile (lazy-load) :thinking: 