### PR TITLE
Make logbook list (table) UI values syncable with route query values 

### DIFF
--- a/src/components/LogbookList/index.vue
+++ b/src/components/LogbookList/index.vue
@@ -1,6 +1,7 @@
 <template>
   <ResponsiveComponentLoader
     v-bind="$attrs"
+    v-on="$listeners"
     for-desktop="LogbookList/table.vue"
     for-mobile="LogbookList/card-list.vue" />
 </template>

--- a/src/components/LogbookList/table.vue
+++ b/src/components/LogbookList/table.vue
@@ -167,7 +167,6 @@ export default {
         }, {
           sync: false
         })
-        this.loadData()
       }
     }
   },
@@ -189,6 +188,7 @@ export default {
       if (sync) {
         this.$emit('update:query', this.mQuery)
       }
+      this.loadData()
     },
     getQueryAsAPISpec () {
       const { page, perPage, startDate, endDate } = this.mQuery

--- a/src/components/ResponsiveComponentLoader/index.js
+++ b/src/components/ResponsiveComponentLoader/index.js
@@ -66,7 +66,8 @@ export default {
   render (h) {
     if (this.component) {
       return h(this.component, {
-        props: this.$attrs || {}
+        props: this.$attrs || {},
+        on: this.$listeners
       })
     }
     return null

--- a/src/views/Logbook/List.vue
+++ b/src/views/Logbook/List.vue
@@ -21,11 +21,15 @@
         </a>
       </div>
     </div>
-    <LogbookList :query="logbookListQuery" />
+    <LogbookList
+      :query="logbookListQuery"
+      @update:query="onLogbookListQueryUpdated" />
   </div>
 </template>
 
 <script>
+import _omitBy from 'lodash/omitBy'
+import _isNil from 'lodash/isNil'
 import { parseQuery } from '../../lib/querystring-parser'
 
 export default {
@@ -45,10 +49,17 @@ export default {
       handler (newObject) {
         this.logbookListQuery = parseQuery(newObject, {
           page: Number,
-          start_date: String,
-          end_date: String
+          startDate: String,
+          endDate: String
         })
       }
+    }
+  },
+  methods: {
+    onLogbookListQueryUpdated (newQuery) {
+      this.$router.push({
+        query: _omitBy(newQuery, _isNil)
+      })
     }
   },
   beforeRouteEnter (to, from, next) {

--- a/src/views/Logbook/List.vue
+++ b/src/views/Logbook/List.vue
@@ -59,6 +59,8 @@ export default {
     onLogbookListQueryUpdated (newQuery) {
       this.$router.push({
         query: _omitBy(newQuery, _isNil)
+      }).catch(() => {
+        // silent error
       })
     }
   },


### PR DESCRIPTION
### Task Description
Pada PR sebelumnya (#131), interaksi antara _route query_ dengan UI masih bersifat satu arah, dimana perubahan pada _route query_ akan menginisiasi/mengubah value pada UI, namun perubahan via UI tidak akan mengubah _route query_.

### Issues
- Pada PR diatas, disebutkan bahwa axios hanya boleh melakukan reload data jika terdapat perubahan _route query_. Hal ini  mengakibatkan `LogbookList` bersifat seperti _router view_ (terikat dengan rute), padahal `LogbookList` adalah komponen yang seharusnya bisa dipakai dimana saja. 

### Proposed Solution
A) Reload data dipicu oleh dan hanya oleh perubahan _internal state_ pada `LogbookList`.
A) Perubahan _route query_ akan memicu perubahan _internal state_ dari `LogbookList`.
C) Perubahan _internal state_ yang diakibatkan oleh datepicker atau paginasi akan memicu _event_ `update:query`. Penggunaan _event_ diserahkan kepada _consumer_, misalnya _router view_ dapat memanfaatkan _event_ tersebut untuk meng-_update route query_ secara paralel.

### Preview
#### Perubahan _route query_ secara manual akan mengubah _internal state_.
![Screen record from 2021-05-20 11 24 01](https://user-images.githubusercontent.com/20709202/118919005-eaf5b380-b95d-11eb-8991-c6404a7e74d1.gif)


#### Perubahan _internal state_ akibat interaksi dengan datepicker dan/atau paginasi akan mengubah _route query_.
![Screen record from 2021-05-20 10 58 19](https://user-images.githubusercontent.com/20709202/118918616-39568280-b95d-11eb-85d0-a1bca3c7022c.gif)
