### PR TITLE
fix duplicate network request

### DIFF
--- a/src/components/LogbookList/table.vue
+++ b/src/components/LogbookList/table.vue
@@ -197,8 +197,9 @@ export default {
       }
       if (sync) {
         this.$emit('update:query', this.mQuery)
+      } else {
+        this.loadData()
       }
-      this.loadData()
     },
     getQueryAsAPISpec () {
       const { page, perPage, startDate, endDate } = this.mQuery


### PR DESCRIPTION
### Deskripsi Bug
Pada [deploy preview ini](https://deploy-preview-135--groupware-jds.netlify.app/), di halaman Laporan, perubahan filter/query menghasilkan network request duplikat (terpanggil 2 kali). Diakibatkan oleh watcher terhadap query yang terpanggil 2 kali.

### Solusi Sementara
Memindahkan reload data ke else block.