### PR TITLE
rename API endpoints for day-off and device-token

### DIFF
--- a/src/components/Attendance/DayoffForm/form-submission.vue
+++ b/src/components/Attendance/DayoffForm/form-submission.vue
@@ -140,7 +140,7 @@ export default {
         Object.entries(this.formattedPayload).forEach(([key, value]) => {
           formData.append(key, value)
         })
-        const post = GroupwareAPI.post('day-off/create', formData)
+        const post = GroupwareAPI.post('day-off/', formData)
         await pMinDelay(post, 1500)
         await this.onSubmitSuccess()
       } catch (e) {

--- a/src/store/modules/dayoff-list.js
+++ b/src/store/modules/dayoff-list.js
@@ -23,7 +23,7 @@ export const mutations = {
 // actions
 export const actions = {
   async getDayoffList (_, { page = 1, perPage = 10 } = {}) {
-    const get = await GroupwareAPI.get('day-off/list', {
+    const get = await GroupwareAPI.get('day-off/', {
       params: {
         page,
         limit: perPage

--- a/src/store/modules/fcm.js
+++ b/src/store/modules/fcm.js
@@ -9,17 +9,15 @@ export const actions = {
   },
   createRegistrationToken ({ rootState }, { token } = {}) {
     return GroupwareAPI.post('notification/device-token/', {
-      userID: rootState.auth.user.id,
-      appID: process.env.VUE_APP_FIREBASE_APP_ID,
-      deviceToken: token
+      app_id: process.env.VUE_APP_FIREBASE_APP_ID,
+      device_token: token
     })
   },
   updateRegistrationToken ({ rootState }, { token } = {}) {
     const userId = rootState.auth.user.id
     return GroupwareAPI.put(`notification/device-token/${userId}`, {
-      userID: rootState.auth.user.id,
-      appID: process.env.VUE_APP_FIREBASE_APP_ID,
-      deviceToken: token
+      app_id: process.env.VUE_APP_FIREBASE_APP_ID,
+      device_token: token
     })
   },
   deleteRegistrationToken ({ rootState }) {

--- a/src/store/modules/fcm.js
+++ b/src/store/modules/fcm.js
@@ -2,13 +2,13 @@ import { GroupwareAPI } from '../../lib/axios'
 
 export const actions = {
   getDeviceTokenByUserId (_, { userId }) {
-    return GroupwareAPI.get(`device-token/detail/${userId}`)
+    return GroupwareAPI.get(`notification/device-token/${userId}`)
       .then((r) => r.data || {})
       .then(({ deviceToken }) => deviceToken || null)
       .catch((e) => null)
   },
   createRegistrationToken ({ rootState }, { token } = {}) {
-    return GroupwareAPI.post('device-token/create', {
+    return GroupwareAPI.post('notification/device-token/', {
       userID: rootState.auth.user.id,
       appID: process.env.VUE_APP_FIREBASE_APP_ID,
       deviceToken: token
@@ -16,7 +16,7 @@ export const actions = {
   },
   updateRegistrationToken ({ rootState }, { token } = {}) {
     const userId = rootState.auth.user.id
-    return GroupwareAPI.put(`device-token/update/${userId}`, {
+    return GroupwareAPI.put(`notification/device-token/${userId}`, {
       userID: rootState.auth.user.id,
       appID: process.env.VUE_APP_FIREBASE_APP_ID,
       deviceToken: token
@@ -24,6 +24,6 @@ export const actions = {
   },
   deleteRegistrationToken ({ rootState }) {
     const userId = rootState.auth.user.id
-    return GroupwareAPI.delete(`device-token/delete/${userId}`)
+    return GroupwareAPI.delete(`notification/device-token/${userId}`)
   }
 }


### PR DESCRIPTION
### Changes
rename API endpoints:
- `POST: day-off/create` -> `POST: day-off/`

- `GET: day-off/list` -> `GET: day-off/`

- `POST: device-token/` -> `POST: notification/device-token/`

- `GET: device-token/:userId` -> `GET: notification/device-token/:userId`

- `PUT: device-token/:userId` -> `PUT: notification/device-token/:userId`

- `DELETE: device-token/:userId`  -> `DELETE: notification/device-token/:userId`