### PR TITLE
use ENVERYWHERE prefix for app mode env value

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,5 +1,6 @@
 # set to 'development' for dev/staging, 'production' for production
 VUE_APP_MODE=development
+ENVERYWHERE_APP_MODE=development
 
 VUE_APP_JDS_PUBLIC_DRIVE=
 VUE_APP_ADMIN_WHATSAPP_NUMBER=

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,9 @@
 [context.deploy-preview.environment]
   VUE_APP_MODE = "development"
+  ENVERYWHERE_APP_MODE = "development"
 [context.master.environment]
   VUE_APP_MODE = "production"
+  ENVERYWHERE_APP_MODE = "production"
 [context.development.environment]
   VUE_APP_MODE = "development"
+  ENVERYWHERE_APP_MODE = "development"

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -5,7 +5,7 @@ importScripts('https://www.gstatic.com/firebasejs/7.18.0/firebase-app.js')
 importScripts('https://www.gstatic.com/firebasejs/7.18.0/firebase-messaging.js')
 
 let firebaseConfig
-if (VUE_APP_MODE !== 'production') {
+if (ENVERYWHERE_APP_MODE !== 'production') {
   firebaseConfig = JSON.parse(ENVERYWHERE_FIREBASE_CRED_STAGING)
 } else {
   firebaseConfig = JSON.parse(ENVERYWHERE_FIREBASE_CRED)


### PR DESCRIPTION
### Issue
VUE_APP_MODE is undefined within `firebase-messaging.sw` worker scope.

### Causes
Enverywhere is only importing env values whose key starts with `ENVERYWHERE_`.
Kindly take a look at current build result (`dist/vue-env.js`).
![image](https://user-images.githubusercontent.com/20709202/124059314-17204c00-da55-11eb-81de-97a2a406a42a.png)

### Fixes
Use `ENVERYWHERE_APP_MODE` inside firebase fcm worker script.
Build result (`dist/vue-env.js`).
![image](https://user-images.githubusercontent.com/20709202/124060943-379dd580-da58-11eb-9225-407d855bfb05.png)
