### PR TITLE
Create attendance rule factory and attendance validator; Use validator to determine attendance list item color;

### DIFF
--- a/src/components/CheckinsList.vue
+++ b/src/components/CheckinsList.vue
@@ -82,8 +82,11 @@
 import { ContentLoader } from 'vue-content-loader'
 import { mapGetters } from 'vuex'
 import { formatTime } from '@/lib/date'
-import { isBefore, isAfter, set } from 'date-fns'
 import { ATTENDANCE } from '../lib/constants'
+import {
+  RULE as ATTENDANCE_RULE,
+  validate as validateAttendance
+} from '../lib/attendance'
 import { moods } from '../components/Reactions'
 
 const moodValues = moods.map((m) => m.value)
@@ -141,27 +144,16 @@ export default {
     },
 
     getRowClass (item) {
-      if (item['message'] !== ATTENDANCE.PRESENT) {
-        return 'bg-white'
+      const attendance = validateAttendance(item)
+      const classes = {
+        [ATTENDANCE_RULE.ONTIME]: 'bg-green-200',
+        [ATTENDANCE_RULE.WARNING]: 'bg-yellow-200',
+        [ATTENDANCE_RULE.DANGER]: 'bg-red-200',
+        [ATTENDANCE_RULE.DAYOFF]: 'bg-white',
+        [ATTENDANCE_RULE.EXCEPTION_MO]: 'bg-white'
       }
 
-      const checkinDateTime = new Date(item['startDate'])
-      const yellowLine = set(checkinDateTime, { hours: 8, minutes: 0, seconds: 0 })
-      const redLine = set(checkinDateTime, { hours: 9, minutes: 0, seconds: 0 })
-
-      if (isAfter(checkinDateTime, redLine)) {
-        return 'bg-red-200'
-      }
-
-      if (isAfter(checkinDateTime, yellowLine)) {
-        return 'bg-yellow-200'
-      }
-
-      if (isBefore(checkinDateTime, yellowLine)) {
-        return 'bg-green-200'
-      }
-
-      return 'bg-white'
+      return classes[attendance] || 'bg-white'
     },
     hasDivisionAndRole (item) {
       return !!item.divisi && !!item.jabatan

--- a/src/components/CheckinsList.vue
+++ b/src/components/CheckinsList.vue
@@ -85,7 +85,7 @@ import { formatTime } from '@/lib/date'
 import { ATTENDANCE } from '../lib/constants'
 import {
   RULE as ATTENDANCE_RULE,
-  validate as validateAttendance
+  getMatchedRule as getMatchedAttendanceRule
 } from '../lib/attendance'
 import { moods } from '../components/Reactions'
 
@@ -144,16 +144,20 @@ export default {
     },
 
     getRowClass (item) {
-      const attendance = validateAttendance(item)
+      // "jabatan" is not a rule of attendance
+      // so it is handled separately
+      if (item.jabatan === 'Monitoring Officer') {
+        return 'bg-white'
+      }
+      const matched = getMatchedAttendanceRule(item)
       const classes = {
         [ATTENDANCE_RULE.ONTIME]: 'bg-green-200',
         [ATTENDANCE_RULE.WARNING]: 'bg-yellow-200',
         [ATTENDANCE_RULE.DANGER]: 'bg-red-200',
-        [ATTENDANCE_RULE.DAYOFF]: 'bg-white',
-        [ATTENDANCE_RULE.EXCEPTION_MO]: 'bg-white'
+        [ATTENDANCE_RULE.DAYOFF]: 'bg-white'
       }
 
-      return classes[attendance] || 'bg-white'
+      return classes[matched] || 'bg-white'
     },
     hasDivisionAndRole (item) {
       return !!item.divisi && !!item.jabatan

--- a/src/lib/attendance/enums.js
+++ b/src/lib/attendance/enums.js
@@ -1,7 +1,0 @@
-export const RULE = {
-  EXCEPTION_MO: 'exception_mo',
-  DAYOFF: 'dayoff',
-  ONTIME: 'ontime',
-  WARNING: 'warning',
-  DANGER: 'danger'
-}

--- a/src/lib/attendance/enums.js
+++ b/src/lib/attendance/enums.js
@@ -1,0 +1,7 @@
+export const RULE = {
+  EXCEPTION_MO: 'exception_mo',
+  DAYOFF: 'dayoff',
+  ONTIME: 'ontime',
+  WARNING: 'warning',
+  DANGER: 'danger'
+}

--- a/src/lib/attendance/index.js
+++ b/src/lib/attendance/index.js
@@ -1,0 +1,2 @@
+export * from './enums'
+export * from './rules'

--- a/src/lib/attendance/index.js
+++ b/src/lib/attendance/index.js
@@ -1,2 +1,2 @@
-export * from './enums'
 export * from './rules'
+export * from './rules.factory'

--- a/src/lib/attendance/rules.factory.js
+++ b/src/lib/attendance/rules.factory.js
@@ -9,10 +9,11 @@ import addMinutes from 'date-fns/addMinutes'
  */
 
 /**
- * @param {string} name - rule name
- * @param {RuleHandler} handler
+ * @param {Object} opts
+ * @param {string} opts.name - rule name
+ * @param {RuleHandler} opts.handler - handler
  */
-export function Rule (name, handler) {
+export function Rule ({ name, handler } = {}) {
   this.name = name
   this.handler = handler
 }

--- a/src/lib/attendance/rules.factory.js
+++ b/src/lib/attendance/rules.factory.js
@@ -1,0 +1,42 @@
+import _inRange from 'lodash/inRange'
+import addMinutes from 'date-fns/addMinutes'
+
+/**
+ * Rule handler.
+ * @callback RuleHandler
+ * @param {Object} checkinData - array element of "/attendance" XHR response data.
+ * @returns {boolean}
+ */
+
+/**
+ * @param {string} name - rule name
+ * @param {RuleHandler} handler
+ */
+export function Rule (name, handler) {
+  this.name = name
+  this.handler = handler
+}
+
+/**
+ * Time range rule factory.
+ * @param {string} start - HH:MM format
+ * @param {string} end - HH:MM format
+ * @returns {Rule}
+ */
+export function createTimeRangeRule (name, start, end) {
+  return {
+    name,
+    handler (checkinData) {
+      const { startDate } = checkinData
+      const value = new Date(startDate).setSeconds(0, 0)
+      const rangeStart = new Date(startDate).setHours(...start.split(':'), 0, 0)
+      const rangeEnd = new Date(startDate).setHours(...end.split(':'), 0, 0)
+
+      return _inRange(
+        +value,
+        addMinutes(+rangeStart, 1),
+        addMinutes(+rangeEnd, 1)
+      )
+    }
+  }
+}

--- a/src/lib/attendance/rules.factory.js
+++ b/src/lib/attendance/rules.factory.js
@@ -3,25 +3,28 @@ import addMinutes from 'date-fns/addMinutes'
 
 /**
  * Rule handler.
- * @callback RuleHandler
- * @param {Object} checkinData - array element of "/attendance" XHR response data.
- * @returns {boolean}
+ * @callback  RuleHandler
+ * @param     {Object} checkinData - array element of "/attendance" XHR response data.
+ * @returns   {boolean}
  */
 
 /**
- * @param {Object} opts
- * @param {string} opts.name - rule name
- * @param {RuleHandler} opts.handler - handler
+ * Rule constructor.
+ * @param {Object}      opts
+ * @param {string}      opts.name     - rule name
+ * @param {RuleHandler} opts.handler  - handler
  */
 export function Rule ({ name, handler } = {}) {
   this.name = name
   this.handler = handler
+  return this
 }
 
 /**
  * Time range rule factory.
- * @param {string} start - HH:MM format
- * @param {string} end - HH:MM format
+ * @param {string} name   - rule name
+ * @param {string} start  - HH:MM format
+ * @param {string} end    - HH:MM format
  * @returns {Rule}
  */
 export function createTimeRangeRule (name, start, end) {

--- a/src/lib/attendance/rules.js
+++ b/src/lib/attendance/rules.js
@@ -16,6 +16,9 @@ const dayoff = new Rule({
 })
 
 /**
+ * If rule is not a typeof time range,
+ * ordering must be based on priotity,
+ * since rule is matched using match-first strategy.
  * @type {Rule[]}
  */
 const rules = [
@@ -26,8 +29,8 @@ const rules = [
 ]
 
 /**
- * @param {Object} checkinData - array element of "/attendance" XHR response data.
- * @returns {string[]} matched rule names
+ * @param {Object}      checkinData - array element of "/attendance" XHR response data.
+ * @returns {string[]}  matched rule names
  */
 export function getMatchedRule (checkinData) {
   let rule

--- a/src/lib/attendance/rules.js
+++ b/src/lib/attendance/rules.js
@@ -40,8 +40,6 @@ function createTimeRangeRule (name, start, end) {
         0
       )
 
-      // no need to worry of clash between rules
-      // due to lodash/inRange is non-inclusive of rangeEnd
       return _inRange(
         +value,
         addMinutes(+rangeStart, 1),

--- a/src/lib/attendance/rules.js
+++ b/src/lib/attendance/rules.js
@@ -1,84 +1,38 @@
-import _inRange from 'lodash/inRange'
-import addMinutes from 'date-fns/addMinutes'
-import { RULE } from './enums'
 import { ATTENDANCE } from '../constants'
+import { Rule, createTimeRangeRule } from './rules.factory'
 
-/**
- * Rule handler.
- * @callback RuleHandler
- * @param {Object} checkinData - array element of "/attendance" XHR response data.
- * @returns {boolean}
- */
-
-/**
- * Rule definition.
- * @typedef {Object} Rule
- * @property {string} [name]
- * @property {RuleHandler} handler
- */
-
-/**
- * Time range rule factory.
- * @param {string} start - HH:MM format
- * @param {string} end - HH:MM format
- * @returns {Rule}
- */
-function createTimeRangeRule (name, start, end) {
-  return {
-    name,
-    handler (checkinData) {
-      const { startDate } = checkinData
-      const value = new Date(startDate).setSeconds(0, 0)
-      const rangeStart = new Date(startDate).setHours(...start.split(':'), 0, 0)
-      const rangeEnd = new Date(startDate).setHours(...end.split(':'), 0, 0)
-
-      return _inRange(
-        +value,
-        addMinutes(+rangeStart, 1),
-        addMinutes(+rangeEnd, 1)
-      )
-    }
-  }
+export const RULE = {
+  DAYOFF: 'dayoff',
+  ONTIME: 'ontime',
+  WARNING: 'warning',
+  DANGER: 'danger'
 }
 
+const dayoff = new Rule(RULE.DAYOFF, (data) => {
+  return data.message !== ATTENDANCE.PRESENT
+})
+
 /**
- * If rule is not a type of time range rule,
- * rules must be ordered based on priority,
- * since rule is matched using match-first strategy.
- *
- * For example, dayoff should come before exception for MO.
  * @type {Rule[]}
  */
 const rules = [
-  {
-    name: RULE.DAYOFF,
-    handler (checkinData) {
-      return checkinData.message !== ATTENDANCE.PRESENT
-    }
-  },
-  {
-    name: RULE.EXCEPTION_MO,
-    handler (checkinData) {
-      // TODO: shouldn't be determined by string matching
-      return checkinData.jabatan === 'Monitoring Officer'
-    }
-  },
+  dayoff,
   createTimeRangeRule(RULE.ONTIME, '00:00', '07:30'),
   createTimeRangeRule(RULE.WARNING, '07:30', '09:00'),
   createTimeRangeRule(RULE.DANGER, '09:00', '24:00')
 ]
 
 /**
- * @param {Date} checkinDate
- * @returns {string | undefined} matched rule name
+ * @param {Object} checkinData - array element of "/attendance" XHR response data.
+ * @returns {string[]} matched rule names
  */
-export function validate (checkinDate) {
-  let result
-  for (const rule of rules) {
-    if (rule.handler(checkinDate)) {
-      result = rule.name
+export function getMatchedRule (checkinData) {
+  let rule
+  for (const r of rules) {
+    if (r.handler(checkinData)) {
+      rule = r.name
       break
     }
   }
-  return result
+  return rule
 }

--- a/src/lib/attendance/rules.js
+++ b/src/lib/attendance/rules.js
@@ -8,8 +8,11 @@ export const RULE = {
   DANGER: 'danger'
 }
 
-const dayoff = new Rule(RULE.DAYOFF, (data) => {
-  return data.message !== ATTENDANCE.PRESENT
+const dayoff = new Rule({
+  name: RULE.DAYOFF,
+  handler (data) {
+    return data.message !== ATTENDANCE.PRESENT
+  }
 })
 
 /**

--- a/src/lib/attendance/rules.js
+++ b/src/lib/attendance/rules.js
@@ -1,0 +1,94 @@
+import _inRange from 'lodash/inRange'
+import addMinutes from 'date-fns/addMinutes'
+import { RULE } from './enums'
+import { ATTENDANCE } from '../constants'
+
+/**
+ * Rule handler.
+ * @callback RuleHandler
+ * @param {Object} checkinData - array element of "/attendance" XHR response data.
+ * @returns {boolean}
+ */
+
+/**
+ * Rule definition.
+ * @typedef {Object} Rule
+ * @property {string} [name]
+ * @property {RuleHandler} handler
+ */
+
+/**
+ * Time range rule factory.
+ * @param {string} start - HH:MM format
+ * @param {string} end - HH:MM format
+ * @returns {Rule}
+ */
+function createTimeRangeRule (name, start, end) {
+  return {
+    name,
+    handler (checkinData) {
+      const { startDate } = checkinData
+      const value = new Date(startDate).setSeconds(0, 0)
+      const rangeStart = new Date(startDate).setHours(
+        ...start.split(':'),
+        0,
+        0
+      )
+      const rangeEnd = new Date(startDate).setHours(
+        ...end.split(':'),
+        0,
+        0
+      )
+
+      // no need to worry of clash between rules
+      // due to lodash/inRange is non-inclusive of rangeEnd
+      return _inRange(
+        +value,
+        addMinutes(+rangeStart, 1),
+        addMinutes(+rangeEnd, 1)
+      )
+    }
+  }
+}
+
+/**
+ * If rule is not a type of time range rule,
+ * rules must be ordered based on priority,
+ * since rule is matched using match-first strategy.
+ *
+ * For example, dayoff should come before exception for MO.
+ * @type {Rule[]}
+ */
+const rules = [
+  {
+    name: RULE.DAYOFF,
+    handler (checkinData) {
+      return checkinData.message !== ATTENDANCE.PRESENT
+    }
+  },
+  {
+    name: RULE.EXCEPTION_MO,
+    handler (checkinData) {
+      // TODO: shouldn't be determined by string matching
+      return checkinData.jabatan === 'Monitoring Officer'
+    }
+  },
+  createTimeRangeRule(RULE.ONTIME, '00:00', '07:30'),
+  createTimeRangeRule(RULE.WARNING, '07:30', '09:00'),
+  createTimeRangeRule(RULE.DANGER, '09:00', '24:00')
+]
+
+/**
+ * @param {Date} checkinDate
+ * @returns {string | undefined} matched rule name
+ */
+export function validate (checkinDate) {
+  let result
+  for (const rule of rules) {
+    if (rule.handler(checkinDate)) {
+      result = rule.name
+      break
+    }
+  }
+  return result
+}

--- a/src/lib/attendance/rules.js
+++ b/src/lib/attendance/rules.js
@@ -29,16 +29,8 @@ function createTimeRangeRule (name, start, end) {
     handler (checkinData) {
       const { startDate } = checkinData
       const value = new Date(startDate).setSeconds(0, 0)
-      const rangeStart = new Date(startDate).setHours(
-        ...start.split(':'),
-        0,
-        0
-      )
-      const rangeEnd = new Date(startDate).setHours(
-        ...end.split(':'),
-        0,
-        0
-      )
+      const rangeStart = new Date(startDate).setHours(...start.split(':'), 0, 0)
+      const rangeEnd = new Date(startDate).setHours(...end.split(':'), 0, 0)
 
       return _inRange(
         +value,


### PR DESCRIPTION
### Task

![image](https://user-images.githubusercontent.com/20709202/132482346-f98fbbcb-bee2-45dd-b829-df8bf4933f90.png)

### Description
For a better rule writing and separation with view layer, logic related to attendance rules is refactored into its own module, placed in `~/lib/attendance`.

Exception for "Monitoring Officer", as required in above task criteria, is not treated as a rule,  since logically an MO can also be on time or late. That requiremet is rather treated as view-layer specific, which is in only on _halaman kehadiran_ page.

### Changes
- Create attendance rule factory
- Create rules based on above task criteria
- Create attendance validator function
- Replace background color determinator in `CheckinList` using above modules.

### Notes
- Due to clashes between time range in above task criteria, e.g `00:00 - 07:30` vs `07:30 - 09:00`, `addMinutes` is used to ensure that a person who checks in at `07:30:59` would still be included in `ontime` category.

### Possible Improvement
An MO might have a night-shift. Time range rule can then be written for that specific use case, since rule handler has access to `checkinData` via its argument.


### Preview

![Screenshot from 2021-09-08 17 30 42](https://user-images.githubusercontent.com/20709202/132494011-f30773d0-d981-4a78-aeff-c0ed78eb8201.png)
![Screenshot from 2021-09-08 17 31 00](https://user-images.githubusercontent.com/20709202/132494007-61127fbd-30c5-4fc8-ba08-51936a5c6ec4.png)
![Screenshot from 2021-09-08 17 31 12](https://user-images.githubusercontent.com/20709202/132494003-47dcc8d7-02c9-408e-a2ba-33a914c05825.png)

